### PR TITLE
Add move constructor and assignment operator to message_t

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -194,9 +194,14 @@ namespace zmq
             return zmq_msg_data (&msg);
         }
 
-        inline size_t size ()
+		inline const void* data () const
         {
-            return zmq_msg_size (&msg);
+            return zmq_msg_data (const_cast<zmq_msg_t*>(&msg));
+        }
+
+        inline size_t size () const
+        {
+            return zmq_msg_size (const_cast<zmq_msg_t*>(&msg));
         }
 
     private:


### PR DESCRIPTION
Hi,

I've added a move constructor and assignment operator to message_t (similar to socket_t and context_t) so I can create methods in the for zmq::message_t MakeMessage().

Could you pull these changes to main?

Ric.
