### PR TITLE
Add const data access to message_t

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -179,9 +179,14 @@ namespace zmq
             return zmq_msg_data (&msg);
         }
 
-        inline size_t size ()
+        inline const void* data () const
         {
-            return zmq_msg_size (&msg);
+            return zmq_msg_data (const_cast<zmq_msg_t*>(&msg));
+        }
+
+        inline size_t size () const
+        {
+            return zmq_msg_size (const_cast<zmq_msg_t*>(&msg));
         }
 
     private:


### PR DESCRIPTION
Add a const version of data() and make size() const so we can pass messages around by
const refeference when we only need read-only data access.
