### PR TITLE
Add explicit close method to context_t

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -237,10 +237,16 @@ namespace zmq
 
         inline ~context_t ()
         {
+            close();
+        }
+
+        inline void close()
+        {
             if (ptr == NULL)
                 return;
             int rc = zmq_term (ptr);
             ZMQ_ASSERT (rc == 0);
+            ptr = NULL;
         }
 
         //  Be careful with this, it's probably only useful for


### PR DESCRIPTION
This commit adds an explicit close method to context_t so we can shutdown zeromq without resorting to newing and deleting a context_t object.
