### PR TITLE
Make single parameter constructors explicit

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -108,7 +108,7 @@ namespace zmq
                 throw error_t ();
         }
 
-        inline message_t (size_t size_)
+        inline explicit message_t (size_t size_)
         {
             int rc = zmq_msg_init_size (&msg, size_);
             if (rc != 0)
@@ -221,7 +221,7 @@ namespace zmq
 
     public:
 
-        inline context_t (int io_threads_)
+        inline explicit context_t (int io_threads_)
         {
             ptr = zmq_init (io_threads_);
             if (ptr == NULL)


### PR DESCRIPTION
Ensures we don't accidentally convert to int to message_t or context_t, for example:

``` c++
void PrintMessage(const zmq::message_t& msg)
{
...
}

PrintMessage(5);  // Currently compiles, it should not
```
