### PR TITLE
Define ZMQ_DELETED_FUNCTION on older clang versions.

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -45,6 +45,8 @@
 
     #if __has_feature(cxx_deleted_functions)
         #define ZMQ_DELETED_FUNCTION = delete
+    #else
+        #define ZMQ_DELETED_FUNCTION
     #endif
 #elif defined(_MSC_VER) && (_MSC_VER >= 1600)
     #define ZMQ_HAS_RVALUE_REFS


### PR DESCRIPTION
If you are using a version of clang that doesn't support cxx_deleted_functions
we need to define ZMQ_DELETED_FUNCTION to be empty.
