### PR TITLE
Allowing for unbind and disconnect

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -365,6 +365,13 @@ namespace zmq
                 throw error_t ();
         }
 
+        inline void disconnect (const char *addr_)
+        {
+            int rc = zmq_disconnect (ptr, addr_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
         inline bool connected()
         {
             return(ptr != NULL);


### PR DESCRIPTION
The functionality provided by zmq_unbind() and zmq_disconnect() was not part of the C++ bindings. Added them like the other C functions.

Is there a reason they were not implemented yet?
