### PR TITLE
Prevent -Wunused-value warnings from non-debug ZMQ_ASSERT macro

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -60,7 +60,7 @@
 #ifndef NDEBUG
 #   define ZMQ_ASSERT(expression) assert(expression)
 #else
-#   define ZMQ_ASSERT(expression) (expression)
+#   define ZMQ_ASSERT(expression) (void)(expression)
 #endif
 
 namespace zmq


### PR DESCRIPTION
Fixed the ZMQ_ASSERT macro, so that in non-debug builds the assert expression result is explicitly discarded. Otherwise it emits 'expression result unused' warnings.
