### PR TITLE
Fix missing include

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -31,6 +31,7 @@
 #include <cassert>
 #include <cstring>
 #include <exception>
+#include <string>
 
 //  Detect whether the compiler supports C++11 rvalue references.
 #if (defined(__GNUC__) && (__GNUC__ > 4 || \


### PR DESCRIPTION
Add a missing include for std::string.
Note that this will also be fixed by PR #22 when ready but I think this PR can be merged immediately in the meantime if everyone's ok.
