### PR TITLE
monitor_t: Avoid compiler warnings resulting from unused method parameters.

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -547,17 +547,17 @@ namespace zmq
         }
 #endif
         virtual void on_monitor_started() {}
-        virtual void on_event_connected(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_connect_delayed(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_connect_retried(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_listening(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_bind_failed(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_accepted(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_accept_failed(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_closed(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_close_failed(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_disconnected(const zmq_event_t &event_, const char* addr_) {}
-        virtual void on_event_unknown(const zmq_event_t &event_, const char* addr_) {}
+        virtual void on_event_connected(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_connect_delayed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_connect_retried(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_listening(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_bind_failed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_accepted(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_accept_failed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_closed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_close_failed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_disconnected(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_unknown(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
     private:
         void* socketPtr;
     };


### PR DESCRIPTION
Currently, the compiler complains about unused parameters (warnings). However, some projects compile their sources by interpreting warnings as errors. And in such settings a build would fail.

I put '(void)' casts into the corresponding empty method bodies in order to suppress these warnings.
