### PR TITLE
Fixes backward compatibility with zmq 3.x

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -492,11 +492,15 @@ namespace zmq
                 if (rc == -1 && zmq_errno() == ETERM)
                     break;
                 assert (rc != -1);
+#if ZMQ_VERSION_MAJOR >= 4
                 const char* data = static_cast<const char*>(zmq_msg_data(&eventMsg));
                 zmq_event_t msgEvent;
                 msgEvent.event = *(uint16_t*)data; data += sizeof(uint16_t);
                 msgEvent.value = *(int32_t*)data;
                 zmq_event_t* event = &msgEvent;
+#else
+                zmq_event_t* event = static_cast<zmq_event_t*>(zmq_msg_data(&eventMsg));
+#endif
                 
 #ifdef ZMQ_NEW_MONITOR_EVENT_LAYOUT
                 zmq_msg_t addrMsg;


### PR DESCRIPTION
The code added in 'Fixed misaligned structure cast' implicitly assumes zmq 4.x, since it relies on new fields in zmq_event_t structure. This commit re-introduces the previous code if zmq < 4.x is detected.
