### PR TITLE
Problem: zmq_event_t removed in libzmq v4.1

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -62,6 +62,11 @@
 
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 1, 0)
 #define ZMQ_HAS_PROXY_STEERABLE
+/*  Socket event data  */
+typedef struct {
+    uint16_t event;  // id of the event as bitfield
+    int32_t  value ; // value is either error code, fd or reconnect interval
+} zmq_event_t;
 #endif
 
 // In order to prevent unused variable warnings when building in non-debug


### PR DESCRIPTION
Solution: define this if we need it, so that caller can use it
on all versions of libzmq.

Fixes #40
