### PR TITLE
Fix a misaligned load

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -500,8 +500,8 @@ namespace zmq
 #if ZMQ_VERSION_MAJOR >= 4
                 const char* data = static_cast<const char*>(zmq_msg_data(&eventMsg));
                 zmq_event_t msgEvent;
-                msgEvent.event = *(uint16_t*)data; data += sizeof(uint16_t);
-                msgEvent.value = *(int32_t*)data;
+                memcpy(&msgEvent.event, data, sizeof(uint16_t)); data += sizeof(uint16_t);
+                memcpy(&msgEvent.value, data, sizeof(int32_t));
                 zmq_event_t* event = &msgEvent;
 #else
                 zmq_event_t* event = static_cast<zmq_event_t*>(zmq_msg_data(&eventMsg));


### PR DESCRIPTION
The issue was discovered by clang:

zmq.hpp:504:34: runtime error: load of misaligned address 0x2b38beb224b2
for type 'int32_t' (aka 'int'), which requires 4 byte alignment

I modified the loads of both event and value to be consistent.