### PR TITLE
Add an rvalue overload for socket_t::send

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -441,6 +441,13 @@ namespace zmq
             throw error_t ();
         }
 
+#ifdef ZMQ_HAS_RVALUE_REFS
+        inline bool send (message_t &&msg_, int flags_ = 0)
+        {
+            return send(msg_, flags_);
+        }
+#endif
+
         inline size_t recv (void *buf_, size_t len_, int flags_ = 0)
         {
             int nbytes = zmq_recv (ptr, buf_, len_, flags_);


### PR DESCRIPTION
This lets you create functions that return message_t's by value, and
pass them to send() with no copy.