### PR TITLE
Don't throw exceptions when using ZMQ_ROUTER_MANDATORY

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -426,7 +426,8 @@ namespace zmq
             int nbytes = zmq_send (ptr, buf_, len_, flags_);
             if (nbytes >= 0)
                 return (size_t) nbytes;
-            if (zmq_errno () == EAGAIN)
+            int zmqErr = zmq_errno ();
+            if (zmqErr == EAGAIN || zmqErr == EHOSTUNREACH)
                 return 0;
             throw error_t ();
         }
@@ -436,7 +437,8 @@ namespace zmq
             int nbytes = zmq_msg_send (&(msg_.msg), ptr, flags_);
             if (nbytes >= 0)
                 return true;
-            if (zmq_errno () == EAGAIN)
+            int zmqErr = zmq_errno ();
+            if (zmqErr == EAGAIN || zmqErr == EHOSTUNREACH)
                 return false;
             throw error_t ();
         }


### PR DESCRIPTION
Previously when using the ZMQ_ROUTER_MANDATORY option on a socket and
sending to an unknown destination, an exception was thrown.

This change makes the send functions to treat the EAGAIN and
EHOSTUNREACH errors similarly.  The user can check zmq_errno() to tell
them apart.