### PR TITLE
Fix backward compatibility

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -417,8 +417,12 @@ namespace zmq
         xsub = ZMQ_XSUB,
         push = ZMQ_PUSH,
         pull = ZMQ_PULL,
+#if ZMQ_VERSION_MAJOR < 4
+        pair = ZMQ_PAIR
+#else
         pair = ZMQ_PAIR,
         stream = ZMQ_STREAM
+#endif
     };
     #endif
 


### PR DESCRIPTION
Fixes this error when building against libzmq3:

zmq.hpp:421:18: error: 'ZMQ_STREAM' was not declared in this scope
         stream = ZMQ_STREAM
                  ^
