### PR TITLE
Fixes assertion error: src/mutex.hpp:123

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -372,16 +372,14 @@ namespace zmq
 
         inline ~context_t () ZMQ_NOTHROW
         {
-            close();
+            int rc = zmq_ctx_destroy (ptr);
+            ZMQ_ASSERT (rc == 0);
         }
 
         inline void close() ZMQ_NOTHROW
         {
-            if (ptr == NULL)
-                return;
-            int rc = zmq_ctx_destroy (ptr);
+            int rc = zmq_ctx_shutdown (ptr);
             ZMQ_ASSERT (rc == 0);
-            ptr = NULL;
         }
 
         //  Be careful with this, it's probably only useful for


### PR DESCRIPTION
The issue is sort o the same as here: https://github.com/zeromq/cppzmq/issues/47
Assertion error, when destroing ctx while creating a socket from a different thread: ./src/mutex.hpp:123
Test program:
clang++ -std=c++1y -stdlib=libc++ test.cc libzmq/src/.libs/libzmq.a -I cppzmq -I libzmq/include -o unfixed  && ./unfixed
Tested with 4-1 HEAD

    #include <thread>
    #include <iostream>
    #include <memory>
    #include "zmq.hpp"
    
    int main() {
      for (int i=0; i< 100000; i++) {
        if (i%10==0)
          std::cout << "iteration " << i << std::endl;
        auto ctx = std::make_shared<zmq::context_t>();
    
        std::thread contextcloser([ctx] {
            ctx->close();
          });
        std::thread socketopener([ctx] {
            zmq::socket_t s(*ctx, ZMQ_DEALER);
          });
        socketopener.join();
        contextcloser.join();
      }
    }