### PR TITLE
Extend C++11 guard to cover remaining use of std::vector data().

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -144,12 +144,12 @@ namespace zmq
     {
         return poll(items.data(), items.size(), timeout.count() );
     }
-    #endif
 
     inline int poll(std::vector<zmq_pollitem_t> const& items, long timeout_ = -1)
     {
         return poll(items.data(), items.size(), timeout_);
     }
+    #endif
 
 
 


### PR DESCRIPTION
Now compiles without error with a pre-C++11 compiler (g++-3.3).

Fixes #53