### PR TITLE
Fix usage of zmq_msg_recv and zmq_recvmsg

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -88,7 +88,7 @@ typedef struct {
 
 // Avoid using deprecated message receive function when possible
 #if ZMQ_VERSION < ZMQ_MAKE_VERSION(3, 2, 0)
-#  define zmq_msg_recv zmq_recvmsg
+#  define zmq_msg_recv(msg, socket, flags) zmq_recvmsg(socket, msg, flags)
 #endif
 
 
@@ -663,7 +663,7 @@ namespace zmq
             while (true) {
                 zmq_msg_t eventMsg;
                 zmq_msg_init (&eventMsg);
-                rc = zmq_msg_recv (s, &eventMsg, 0);
+                rc = zmq_msg_recv (&eventMsg, s, 0);
                 if (rc == -1 && zmq_errno() == ETERM)
                     break;
                 assert (rc != -1);
@@ -680,7 +680,7 @@ namespace zmq
 #ifdef ZMQ_NEW_MONITOR_EVENT_LAYOUT
                 zmq_msg_t addrMsg;
                 zmq_msg_init (&addrMsg);
-                rc = zmq_msg_recv (s, &addrMsg, 0);
+                rc = zmq_msg_recv (&addrMsg, s, 0);
                 if (rc == -1 && zmq_errno() == ETERM)
                     break;
                 assert (rc != -1);


### PR DESCRIPTION
The zmq_msg_recv() function takes its parameters in the order of message, socket, and flags while the zmq_recvmsg() function takes the socket, message, and flags. This commit addresses that difference.