### PR TITLE
Fix warning 4996 in msvc debug build

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -219,7 +219,12 @@ namespace zmq
             int const rc = zmq_msg_init_size (&msg, size_);
             if (rc != 0)
                 throw error_t ();
-            std::copy(first, last, static_cast<value_t*>(zmq_msg_data (&msg)) );
+            value_t* dest = data<value_t>();
+            while (first != last)
+            {
+                *dest = *first;
+                ++dest; ++first;
+            }
         }
 
         inline message_t (void *data_, size_t size_, free_fn *ffn_,


### PR DESCRIPTION
When making a debug build with msvc, the range constructor of message_t caused warning 4996: 'std::_Copy_impl': Function call with parameters that may be unsafe. It is actually safe to do what's done in the constructor, so the workaround is to mimic what std::copy does, whitout the range check.