### PR TITLE
Updating zmq_ctx_shutdown to zmq_ctx_destroy which is imported in zmq.h

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -408,7 +408,7 @@ namespace zmq
 
         inline void close() ZMQ_NOTHROW
         {
-            int rc = zmq_ctx_shutdown (ptr);
+            int rc = zmq_ctx_destroy (ptr);
             ZMQ_ASSERT (rc == 0);
         }
 


### PR DESCRIPTION
Zeromq 3.2.5 exports zmq_ctx_destroy and not zmq_ctx_shutdown.