### PR TITLE
Fixed context_t::close and context_t::~context_t

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -410,13 +410,16 @@ namespace zmq
 
         inline ~context_t () ZMQ_NOTHROW
         {
-            int rc = zmq_ctx_destroy (ptr);
-            ZMQ_ASSERT (rc == 0);
+            if (ptr)
+            {
+              close();
+            }
         }
 
         inline void close() ZMQ_NOTHROW
         {
             int rc = zmq_ctx_destroy (ptr);
+            ptr = NULL;
             ZMQ_ASSERT (rc == 0);
         }
 


### PR DESCRIPTION
Restored behaviour before 014628cb34735cfdf8d049e2316574f713361e5a and 971092e472b5b68d36334e88cb35f75972c35415 such that the context is properly destroyed AND close may be called explicitly without causing an assertion in the dtor
