### PR TITLE
Remove explicit cast on void pointer operator

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -495,12 +495,12 @@ namespace zmq
             close();
         }
 
-        inline ZMQ_EXPLICIT operator void* () ZMQ_NOTHROW
+        inline operator void* () ZMQ_NOTHROW
         {
             return ptr;
         }
 
-        inline ZMQ_EXPLICIT operator void const* () const ZMQ_NOTHROW
+        inline operator void const* () const ZMQ_NOTHROW
         {
             return ptr;
         }


### PR DESCRIPTION
As opposed in #80 it makes no sense to use explicit casting on a void pointer operator. Also is causes a `cannot convert socket to void*` error since the conversion can no longer be auto deducted.