### PR TITLE
Failing assertion in dtor of context_t

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -410,14 +410,17 @@ namespace zmq
 
         inline ~context_t () ZMQ_NOTHROW
         {
-            int rc = zmq_ctx_destroy (ptr);
-            ZMQ_ASSERT (rc == 0);
+            close();
         }
 
         inline void close() ZMQ_NOTHROW
         {
+            if (ptr == NULL)
+                return;
+
             int rc = zmq_ctx_destroy (ptr);
             ZMQ_ASSERT (rc == 0);
+            ptr = NULL;
         }
 
         //  Be careful with this, it's probably only useful for


### PR DESCRIPTION
Assertion in destructor of _context_t_ doesn't fail if _close_ method has already been called.