### PR TITLE
lack of head file

### DIFF
--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -27,6 +27,7 @@
 #include <deque>
 #include <iomanip>
 #include <sstream>
+#include <stdexcept>
 
 namespace zmq {
 


### PR DESCRIPTION
lack of `#include <stdexcept>` in function poptyp when call `throw runtime_error`