### PR TITLE
reduce copy when send mem block

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -622,7 +622,7 @@ namespace zmq
 
         inline size_t send (const void *buf_, size_t len_, int flags_ = 0)
         {
-            int nbytes = zmq_send (ptr, buf_, len_, flags_);
+            int nbytes = zmq_send_const (ptr, buf_, len_, flags_);
             if (nbytes >= 0)
                 return (size_t) nbytes;
             if (zmq_errno () == EAGAIN)


### PR DESCRIPTION
change `zmq_send`  to `zmq_send_const`  for reduce copy in `size_t send (const void *, size_t, int)`