### PR TITLE
misuse of zmq_send_const

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -624,11 +624,7 @@ namespace zmq
 
         inline size_t send (const void *buf_, size_t len_, int flags_ = 0)
         {
-#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 0, 8)
-            int nbytes = zmq_send_const (ptr, buf_, len_, flags_);
-#else
             int nbytes = zmq_send (ptr, buf_, len_, flags_);
-#endif
             if (nbytes >= 0)
                 return (size_t) nbytes;
             if (zmq_errno () == EAGAIN)


### PR DESCRIPTION
It's a misuse of `zmq_send_const`. In function `inline size_t send (const void *buf_, size_t len_, int flags_ = 0)`

This lead to many mistake.

the `zmq_send_const` should be used to send a const mem block, but we may send a std::string which alloc in the stack space. like `sock.send(str.data(), str.size())`. So it's not right to use zmq_send_const here.

I'm sorry for pull it last week.