### PR TITLE
fix warning unused but set variable

### DIFF
--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -396,8 +396,8 @@ public:
     // Self test
     static int test()
     {
-        bool ok = true;
-        float num = 0;
+        bool ok = true; (void) ok;
+        float num = 0; (void) num;
         std::string str = "";
         message_t msg;
 


### PR DESCRIPTION
if we include target code in c++11 with `-Wall -DNDEBUG`, there are some warning, unused-but-set-variable