### PR TITLE
update directive for ZMQ_MAKE_VERSION check against zmq_msg_gets method

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -373,7 +373,7 @@ namespace zmq
             return a == b;
         }
 
-#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 0, 8)
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 1, 0)
         inline const char* gets(const char *property_)
         {
             const char* value = zmq_msg_gets (&msg, property_);


### PR DESCRIPTION
This PR fixes issue submitted #113 to support the legacy stable release tree 4.0.x where zmq_msg_gets() in not available.   