### PR TITLE
cmake: Export targets to package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ project(cppzmq)
 
 find_package(ZeroMQ REQUIRED)
 
+if (ZeroMQ_FOUND AND (NOT TARGET libzmq OR NOT TARGET libzmq-static))
+  message(FATAL_ERROR "ZeroMQ version not supported!")
+endif()
+
 set (${PROJECT_NAME}_VERSION ${ZeroMQ_VERSION})
 message(STATUS "cppzmq v${${PROJECT_NAME}_VERSION}")
 
@@ -11,8 +15,20 @@ set(CPPZMQ_HEADERS
     zmq_addon.hpp
 )
 
+foreach (target cppzmq cppzmq-static)
+  add_library(${target} INTERFACE)
+  target_include_directories(${target} INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                                                 $<INSTALL_INTERFACE:include>)
+endforeach()
+
+target_link_libraries(cppzmq INTERFACE libzmq)
+target_link_libraries(cppzmq-static INTERFACE libzmq-static)
+
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+
+install(TARGETS cppzmq cppzmq-static
+        EXPORT ${PROJECT_NAME}-targets)
 
 install(FILES ${CPPZMQ_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
@@ -20,12 +36,19 @@ install(FILES ${CPPZMQ_HEADERS}
 # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
 set(CPPZMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for cppzmqConfig.cmake")
 
+if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+  export(EXPORT ${PROJECT_NAME}-targets
+         FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
+endif()
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
                               INSTALL_DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
                                  VERSION ${${PROJECT_NAME}_VERSION}
                                  COMPATIBILITY AnyNewerVersion)
+install(EXPORT ${PROJECT_NAME}-targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
               DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})

--- a/cppzmqConfig.cmake.in
+++ b/cppzmqConfig.cmake.in
@@ -1,4 +1,12 @@
 # cppzmq cmake module
+#
+# The following import targets are created
+#
+# ::
+#
+#   cppzmq-static
+#   cppzmq
+#
 # This module sets the following variables in your project::
 #
 # cppzmq_FOUND - true if cppzmq found on the system
@@ -8,8 +16,13 @@
 
 @PACKAGE_INIT@
 
-set(PN cppzmq)
-set_and_check(${PN}_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
-set_and_check(${PN}_LIBRARY "@ZeroMQ_LIBRARY@")
-set_and_check(${PN}_STATIC_LIBRARY "@ZeroMQ_STATIC_LIBRARY@")
-check_required_components(${PN})
+include(CMakeFindDependencyMacro)
+find_dependency(ZeroMQ)
+
+if(NOT TARGET @PROJECT_NAME@)
+  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+  get_target_property(@PROJECT_NAME@_INCLUDE_DIR cppzmq INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(@PROJECT_NAME@_LIBRARY libzmq LOCATION)
+  get_target_property(@PROJECT_NAME@_STATIC_LIBRARY libzmq-static LOCATION)
+endif()


### PR DESCRIPTION
Export CMake targets to package config via interface libraries. This
allows the user to simple depends on this project and thereby gets
the additionally dependencies like ZeroMQ automatically.

This pull request depends on pull request zeromq/libzmq#2504.