### PR TITLE
Fix rvalue for socket::send() on EHOSTUNREACH

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -631,6 +631,8 @@ namespace zmq
                 return (size_t) nbytes;
             if (zmq_errno () == EAGAIN)
                 return 0;
+            if (zmq_errno () == EHOSTUNREACH)
+                return 0;
             throw error_t ();
         }
 
@@ -640,6 +642,8 @@ namespace zmq
             if (nbytes >= 0)
                 return true;
             if (zmq_errno () == EAGAIN)
+                return false;
+            if (zmq_errno () == EHOSTUNREACH)
                 return false;
             throw error_t ();
         }


### PR DESCRIPTION
@bluca As discussed yesterday in the IRC, I found two issues with C++ example (ROUTER/DEALER loosing msgs [1]):

1) `EHOSTUNREACH` was incorrectly handled (something we discussed already). This PR handles this by treating it as other non-terminal errors, like `EAGAIN`.

2) I've realised `send()` with flags `ZMQ_DONTWAIT | ZMQ_SNDMORE` actually ignores `ZMQ_SNDMORE` and sends it **immediately**. This is why the second send in the broker code in the example sent was failing with `EHOSTUNREACH` exception, as was considering 2nd msg as ZID (I guess) and NULL was an unseen as a ZID yet.

For 2); is this the expected behaviour? I would expect this should either ignore `ZMQ_DONTWAIT` or give an `EINVAL` return code. If it's an issue, then it must be a libzmq issue.

Original code of example that triggered the discussion:
[1] https://pastebin.com/AvDEMM1d

===

During introduction of EHOSTUNREACH, missing mapping between
EHOSTUNREACH errno and false/0 return code for socket's send()
calls was missing, throwing an exception.

To be consistent with the rest of wrappers (e.g. DONTWAIT), fix it
by handling this errno as a regular EAGAIN, and let the caller use
errno/zmq_errno() to branch on their code.