### PR TITLE
Problem: uninitialized context pointer in socket_t move constructor

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -506,9 +506,12 @@ namespace zmq
         #endif
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-        inline socket_t(socket_t&& rhs) ZMQ_NOTHROW : ptr(rhs.ptr)
+        inline socket_t(socket_t&& rhs) ZMQ_NOTHROW :
+            ptr(rhs.ptr),
+            ctxptr(rhs.ctxptr)
         {
-            rhs.ptr = NULL;
+            rhs.ptr    = NULL;
+            rhs.ctxptr = NULL;
         }
         inline socket_t& operator=(socket_t&& rhs) ZMQ_NOTHROW
         {


### PR DESCRIPTION
This can cause monitor_t to crash if used with a socket that was
constructed via the move constructor.

Solution: initialise the context pointer variable ctxptr in the move
constructor.