### PR TITLE
CMake: pkg-config Fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,35 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cppzmq)
 
-find_package(ZeroMQ REQUIRED)
+find_package(ZeroMQ)
+
+# libzmq autotools install: fallback to pkg-config
+if(NOT ZeroMQ_FOUND)
+    find_package(PkgConfig)
+    pkg_check_modules(PC_LIBZMQ QUIET libzmq)
+
+    set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
+    find_library(ZeroMQ_LIBRARY NAMES libzmq.so
+                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
+    find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq.a
+                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
+
+    add_library(libzmq SHARED IMPORTED)
+    set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
+
+    add_library(libzmq-static STATIC IMPORTED ${PC_LIBZMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
+
+    if(ZeroMQ_LIBRARY AND ZeroMQ_STATIC_LIBRARY)
+        set(ZeroMQ_FOUND ON)
+    endif()
+endif()
+
+if(NOT ZeroMQ_FOUND)
+    message(FATAL_ERROR "ZeroMQ was NOT found!")
+endif()
 
 if (ZeroMQ_FOUND AND (NOT TARGET libzmq OR NOT TARGET libzmq-static))
   message(FATAL_ERROR "ZeroMQ version not supported!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.0)
 project(cppzmq)
 
 find_package(ZeroMQ)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,26 +5,7 @@ find_package(ZeroMQ)
 
 # libzmq autotools install: fallback to pkg-config
 if(NOT ZeroMQ_FOUND)
-    find_package(PkgConfig)
-    pkg_check_modules(PC_LIBZMQ QUIET libzmq)
-
-    set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
-    find_library(ZeroMQ_LIBRARY NAMES libzmq.so
-                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
-    find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq.a
-                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
-
-    add_library(libzmq SHARED IMPORTED)
-    set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
-    set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
-
-    add_library(libzmq-static STATIC IMPORTED ${PC_LIBZMQ_INCLUDE_DIRS})
-    set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
-    set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
-
-    if(ZeroMQ_LIBRARY AND ZeroMQ_STATIC_LIBRARY)
-        set(ZeroMQ_FOUND ON)
-    endif()
+    include(${CMAKE_CURRENT_LIST_DIR}/libzmqPkgConfigFallback.cmake)
 endif()
 
 if(NOT ZeroMQ_FOUND)
@@ -79,4 +60,5 @@ install(EXPORT ${PROJECT_NAME}-targets
         DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+              ${CMAKE_SOURCE_DIR}/libzmqPkgConfigFallback.cmake
               DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})

--- a/cppzmqConfig.cmake.in
+++ b/cppzmqConfig.cmake.in
@@ -21,26 +21,7 @@ find_package(ZeroMQ)
 
 # libzmq autotools install: fallback to pkg-config
 if(NOT ZeroMQ_FOUND)
-    find_package(PkgConfig)
-    pkg_check_modules(PC_LIBZMQ QUIET libzmq)
-
-    set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
-    find_library(ZeroMQ_LIBRARY NAMES libzmq.so
-                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
-    find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq.a
-                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
-
-    add_library(libzmq SHARED IMPORTED)
-    set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
-    set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
-
-    add_library(libzmq-static STATIC IMPORTED ${PC_LIBZMQ_INCLUDE_DIRS})
-    set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
-    set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
-
-    if(ZeroMQ_LIBRARY AND ZeroMQ_STATIC_LIBRARY)
-        set(ZeroMQ_FOUND ON)
-    endif()
+    include(${CMAKE_CURRENT_LIST_DIR}/libzmqPkgConfigFallback.cmake)
 endif()
 
 if(NOT ZeroMQ_FOUND)

--- a/cppzmqConfig.cmake.in
+++ b/cppzmqConfig.cmake.in
@@ -17,7 +17,35 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(ZeroMQ)
+find_package(ZeroMQ)
+
+# libzmq autotools install: fallback to pkg-config
+if(NOT ZeroMQ_FOUND)
+    find_package(PkgConfig)
+    pkg_check_modules(PC_LIBZMQ QUIET libzmq)
+
+    set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
+    find_library(ZeroMQ_LIBRARY NAMES libzmq.so
+                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
+    find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq.a
+                 PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
+
+    add_library(libzmq SHARED IMPORTED)
+    set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
+
+    add_library(libzmq-static STATIC IMPORTED ${PC_LIBZMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
+    set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
+
+    if(ZeroMQ_LIBRARY AND ZeroMQ_STATIC_LIBRARY)
+        set(ZeroMQ_FOUND ON)
+    endif()
+endif()
+
+if(NOT ZeroMQ_FOUND)
+    message(FATAL_ERROR "ZeroMQ was NOT found!")
+endif()
 
 if(NOT TARGET @PROJECT_NAME@)
   include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/libzmqPkgConfigFallback.cmake
+++ b/libzmqPkgConfigFallback.cmake
@@ -1,0 +1,20 @@
+find_package(PkgConfig)
+pkg_check_modules(PC_LIBZMQ QUIET libzmq)
+
+set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
+find_library(ZeroMQ_LIBRARY NAMES libzmq.so
+             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
+find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq.a
+             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
+
+add_library(libzmq SHARED IMPORTED)
+set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
+set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
+
+add_library(libzmq-static STATIC IMPORTED ${PC_LIBZMQ_INCLUDE_DIRS})
+set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
+set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
+
+if(ZeroMQ_LIBRARY AND ZeroMQ_STATIC_LIBRARY)
+    set(ZeroMQ_FOUND ON)
+endif()


### PR DESCRIPTION
Try to find installs of `libzmq` that were performed with autotools with a `pkg-config` fallback. Close #132

@herbrechtsmeier we are trying to add a `pkg-config` fallback for `cppzmq`'s `CMakeLists.txt` to find `libzmq` installs that were done with autotools and thus have no ZeroMQ cmake module around.

Do you have an idea how we can re-introduce the targets you are using for the libs when found via `pkg-config`?