### PR TITLE
Update zmq.hpp

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -703,7 +703,7 @@ namespace zmq
     class monitor_t
     {
     public:
-        monitor_t() : socketPtr(NULL), monitor_socket{NULL} {}
+        monitor_t() : socketPtr(NULL), monitor_socket(NULL) {}
 
         virtual ~monitor_t()
         {


### PR DESCRIPTION
Line 706 constructor was:   
monitor_t() : socketPtr(NULL), monitor_socket{NULL} {}
but should be:
monitor_t() : socketPtr(NULL), monitor_socket(NULL) {}

Note change of bracket types for monitor_socket parameter.