### PR TITLE
Problem: inconsistency with DRAFT APIs in libzmq 4.2.x

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -859,6 +859,7 @@ namespace zmq
                 on_event_disconnected(*event, address.c_str());
                 break;
 #ifdef ZMQ_BUILD_DRAFT_API
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 3)
             case ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL:
                 on_event_handshake_failed(*event, address.c_str());
                 break;
@@ -869,8 +870,16 @@ namespace zmq
                 on_event_handshake_failed(*event, address.c_str());
                 break;
             case ZMQ_EVENT_HANDSHAKE_SUCCEEDED:
-                on_event_handshake_succeed(*event, address.c_str());
+                on_event_handshake_succeeded(*event, address.c_str());
                 break;
+#elif ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 1)
+            case ZMQ_EVENT_HANDSHAKE_FAILED:
+                on_event_handshake_failed(*event, address.c_str());
+                break;
+            case ZMQ_EVENT_HANDSHAKE_SUCCEED:
+                on_event_handshake_succeeded(*event, address.c_str());
+                break;
+#endif
 #endif
             default:
                 on_event_unknown(*event, address.c_str());
@@ -905,8 +914,15 @@ namespace zmq
         virtual void on_event_closed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
         virtual void on_event_close_failed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
         virtual void on_event_disconnected(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 3)
+        virtual void on_event_handshake_failed_no_detail(const zmq_event_t &event_, const char* addr_) { (void) event_; (void) addr_; }
+        virtual void on_event_handshake_failed_protocol(const zmq_event_t &event_, const char* addr_) { (void) event_; (void) addr_; }
+        virtual void on_event_handshake_failed_auth(const zmq_event_t &event_, const char* addr_) { (void) event_; (void) addr_; }
+        virtual void on_event_handshake_succeeded(const zmq_event_t &event_, const char* addr_) { (void) event_; (void) addr_; }
+#elif ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 1)
         virtual void on_event_handshake_failed(const zmq_event_t &event_, const char* addr_) { (void) event_; (void) addr_; }
         virtual void on_event_handshake_succeed(const zmq_event_t &event_, const char* addr_) { (void) event_; (void) addr_; }
+#endif		
         virtual void on_event_unknown(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
     private:
 
@@ -961,7 +977,11 @@ namespace zmq
                 return true;
             }
 
-            if (zmq_errno ()  == ETIMEDOUT)
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 3)
+            if (zmq_errno () == EAGAIN)
+#else			
+            if (zmq_errno () == ETIMEDOUT)
+#endif			
                 return false;
 
             throw error_t ();


### PR DESCRIPTION
Solution: distinguish cases for libzmq 4.2.0, 4.2.1/4.2.2 and 4.2.3