### PR TITLE
Removing ambiguous overload of poll

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -149,11 +149,6 @@ namespace zmq
         return rc;
     }
 
-    inline int poll(zmq_pollitem_t const* items, size_t nitems)
-    {
-        return poll(items, nitems, -1);
-    }
-
     #ifdef ZMQ_CPP11
     inline int poll(zmq_pollitem_t const* items, size_t nitems, std::chrono::milliseconds timeout)
     {


### PR DESCRIPTION
There are two overloads of `poll` - one that has `-1` as the default value for the timeout, and one that does not have the timeout argument (which calls the previous one with -1 for the timeout). This makes it ambiguous for the compiler when `poll` is called without the timeout.

This patch removes the second overload as it is not needed since the first one already covers the same case.