### PR TITLE
fix libzmqPkgConfigFallback.cmake for find library in macOS and MinGW

### DIFF
--- a/libzmqPkgConfigFallback.cmake
+++ b/libzmqPkgConfigFallback.cmake
@@ -2,9 +2,9 @@ find_package(PkgConfig)
 pkg_check_modules(PC_LIBZMQ QUIET libzmq)
 
 set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
-find_library(ZeroMQ_LIBRARY NAMES libzmq.so
+find_library(ZeroMQ_LIBRARY NAMES libzmq.so libzmq.dylib libzmq.dll
              PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
-find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq.a
+find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq.a libzmq.dll.a
              PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
 
 add_library(libzmq SHARED IMPORTED)


### PR DESCRIPTION
tested on macOS.
for MinGW, just add the corresponding file name but not tested.