### PR TITLE
Revert "Fix compile error for libzmq 4.2.1 and 4.2.2"

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -872,7 +872,7 @@ namespace zmq
                 on_event_handshake_failed(*event, address.c_str());
                 break;
             case ZMQ_EVENT_HANDSHAKE_SUCCEED:
-                on_event_handshake_succeed(*event, address.c_str());
+                on_event_handshake_succeeded(*event, address.c_str());
                 break;
 #endif
 #endif


### PR DESCRIPTION
Reverts zeromq/cppzmq#161

I don't think this change is a good idea. The set of events changed between 4.2.2 and 4.2.3(unreleased). One change involved changing the name of ZMQ_EVENT_HANDSHAKE_SUCCEED to ZMQ_EVENT_HANDSHAKE_SUCCEEDED. The method names in cppzmq on_* correspond to the libzmq events and their names 1-to-1. 

This change removes this 1-to-1 mapping, which is confusing.

cppzmq makes no attempt to map different (DRAFT) API versions of libzmq to a uniform API. While this might appear okay for this identifier, which only contains a typo, a client library of cppzmq must be aware of the exact version of libzmq that is used. 
