### PR TITLE
Revert "Revert "Fix compile error for libzmq 4.2.1 and 4.2.2""

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -872,7 +872,7 @@ namespace zmq
                 on_event_handshake_failed(*event, address.c_str());
                 break;
             case ZMQ_EVENT_HANDSHAKE_SUCCEED:
-                on_event_handshake_succeeded(*event, address.c_str());
+                on_event_handshake_succeed(*event, address.c_str());
                 break;
 #endif
 #endif


### PR DESCRIPTION
Reverts zeromq/cppzmq#162

I am very sorry, I did not read the original PR right. My PR #162 was wrong, #161 was correct. Sorry for that and thanks to @FrankAdesys for taking the time to detail this out.