### PR TITLE
call pkg-config fallback FindZeroMQ.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,9 @@ find_package(ZeroMQ QUIET)
 
 # libzmq autotools install: fallback to pkg-config
 if(NOT ZeroMQ_FOUND)
-    include(${CMAKE_CURRENT_LIST_DIR}/libzmqPkgConfigFallback.cmake)
-endif()
-
-if(NOT ZeroMQ_FOUND)
-    message(FATAL_ERROR "ZeroMQ was NOT found!")
+    # try again with pkg-config (normal install of zeromq)
+    list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/libzmq-pkg-config)
+    find_package(ZeroMQ REQUIRED)
 endif()
 
 if (ZeroMQ_FOUND AND (NOT TARGET libzmq OR NOT TARGET libzmq-static))
@@ -60,5 +58,7 @@ install(EXPORT ${PROJECT_NAME}-targets
         DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-              ${CMAKE_SOURCE_DIR}/libzmqPkgConfigFallback.cmake
+              ${CMAKE_SOURCE_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
               DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
+install(FILES ${CMAKE_SOURCE_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
+              DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR}/libzmq-pkg-config)

--- a/libzmq-pkg-config/FindZeroMQ.cmake
+++ b/libzmq-pkg-config/FindZeroMQ.cmake
@@ -7,6 +7,15 @@ find_library(ZeroMQ_LIBRARY NAMES libzmq.so libzmq.dylib libzmq.dll
 find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq.a libzmq.dll.a
              PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
 
+if(ZeroMQ_LIBRARY AND ZeroMQ_STATIC_LIBRARY)
+    set(ZeroMQ_FOUND ON)
+endif()
+
+if (TARGET libzmq)
+    # avoid errors defining targets twice
+    return()
+endif()
+
 add_library(libzmq SHARED IMPORTED)
 set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
 set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
@@ -14,7 +23,3 @@ set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
 add_library(libzmq-static STATIC IMPORTED ${PC_LIBZMQ_INCLUDE_DIRS})
 set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
 set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
-
-if(ZeroMQ_LIBRARY AND ZeroMQ_STATIC_LIBRARY)
-    set(ZeroMQ_FOUND ON)
-endif()


### PR DESCRIPTION
and add it to CMAKE_MODULE_PATH on failed load

this allows downstream packages that have loaded cppzmq to call find_package(ZeroMQ) and succeed without shipping their own copy of the fallback.

Additionally, a check for if the libzmq target is defined avoids duplicate definitions when called multiple times, or if multiple packages have the same shim.