### PR TITLE
fix installation source path of FindZeroMQ.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,5 +59,5 @@ install(EXPORT ${PROJECT_NAME}-targets
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
               DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
-install(FILES ${CMAKE_SOURCE_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
               DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR}/libzmq-pkg-config)


### PR DESCRIPTION
when cppzmq is not the root folder of cmake (i.e., it is embedded in a
super project), CMAKE_SOURCE_DIR will not be the correct path to copy
FindZeroMQ.cmake.