### PR TITLE
Problem: message_t could be easier to construct and is missing equal not equal operators

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ fetch_googletest(
 
 add_executable(
     unit_tests
+    message.cpp
     context.cpp
     socket.cpp
     poller.cpp

--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include <zmq.hpp>
+
+TEST (message, create_destroy)
+{
+    zmq::message_t message;
+}
+
+TEST (message, constructors)
+{
+    const std::string hi {"Hi"};
+    zmq::message_t hi_msg_a {hi.begin (), hi.end ()};
+    ASSERT_EQ (hi_msg_a.size (), hi.size ());
+    zmq::message_t hi_msg_b {hi.data (), hi.size ()};
+    ASSERT_EQ (hi_msg_b.size (), hi.size ());
+    ASSERT_EQ (hi_msg_a, hi_msg_b);
+#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)
+    zmq::message_t hello_msg_a {"Hello"};
+    ASSERT_NE (hi_msg_a, hello_msg_a);
+    ASSERT_NE (hi_msg_b, hello_msg_a);
+    zmq::message_t hi_msg_c {hi};
+    ASSERT_EQ (hi_msg_c, hi_msg_a);
+    ASSERT_EQ (hi_msg_c, hi_msg_b);
+    ASSERT_NE (hi_msg_c, hello_msg_a);
+#endif
+#ifdef ZMQ_HAS_RVALUE_REFS
+    zmq::message_t hello_msg_b{zmq::message_t{"Hello"}};
+    ASSERT_EQ (hello_msg_a, hello_msg_b);
+#endif
+}

--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -8,23 +8,23 @@ TEST (message, create_destroy)
 
 TEST (message, constructors)
 {
-    const std::string hi {"Hi"};
-    zmq::message_t hi_msg_a {hi.begin (), hi.end ()};
+    const std::string hi ("Hi");
+    zmq::message_t hi_msg_a (hi.begin (), hi.end ());
     ASSERT_EQ (hi_msg_a.size (), hi.size ());
-    zmq::message_t hi_msg_b {hi.data (), hi.size ()};
+    zmq::message_t hi_msg_b (hi.data (), hi.size ());
     ASSERT_EQ (hi_msg_b.size (), hi.size ());
     ASSERT_EQ (hi_msg_a, hi_msg_b);
 #if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)
-    zmq::message_t hello_msg_a {"Hello"};
+    zmq::message_t hello_msg_a ("Hello");
     ASSERT_NE (hi_msg_a, hello_msg_a);
     ASSERT_NE (hi_msg_b, hello_msg_a);
-    zmq::message_t hi_msg_c {hi};
+    zmq::message_t hi_msg_c (hi);
     ASSERT_EQ (hi_msg_c, hi_msg_a);
     ASSERT_EQ (hi_msg_c, hi_msg_b);
     ASSERT_NE (hi_msg_c, hello_msg_a);
 #endif
 #ifdef ZMQ_HAS_RVALUE_REFS
-    zmq::message_t hello_msg_b{zmq::message_t{"Hello"}};
+    zmq::message_t hello_msg_b(zmq::message_t("Hello"));
     ASSERT_EQ (hello_msg_a, hello_msg_b);
 #endif
 }

--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -167,10 +167,7 @@ TEST(poller, poll_basic)
     zmq::socket_t sink{context, zmq::socket_type::pull};
     ASSERT_NO_THROW(sink.connect(endpoint));
 
-    const std::string message = "H";
-
-    // TODO: send overload for string would be handy.
-    ASSERT_NO_THROW(vent.send(std::begin(message), std::end(message)));
+    ASSERT_NO_THROW(vent.send("Hi"));
 
     zmq::poller_t poller;
     bool message_received = false;
@@ -217,7 +214,7 @@ TEST(poller, client_server)
     // Setup client and send message
     zmq::socket_t client{context, zmq::socket_type::dealer};
     ASSERT_NO_THROW(client.connect(endpoint));
-    ASSERT_NO_THROW(client.send(std::begin(send_msg), std::end(send_msg)));
+    ASSERT_NO_THROW(client.send(send_msg));
 
     ASSERT_NO_THROW(poller.wait(std::chrono::milliseconds{-1}));
     ASSERT_TRUE(got_pollin);

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -271,6 +271,12 @@ namespace zmq
                 throw error_t ();
         }
 
+#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)
+        template<typename T> message_t (const T &msg_)
+            : message_t (std::begin (msg_), std::end (msg_))
+        {}
+#endif
+
 #ifdef ZMQ_HAS_RVALUE_REFS
         inline message_t (message_t &&rhs): msg (rhs.msg)
         {
@@ -379,13 +385,28 @@ namespace zmq
             return static_cast<T const*>( data() );
         }
 
+        ZMQ_DEPRECATED("from 4.3.0, use operator== instead")
         inline bool equal(const message_t* other) const ZMQ_NOTHROW
         {
             if (size() != other->size())
                 return false;
-            std::string a(data<char>(), size());
-            std::string b(other->data<char>(), other->size());
+            const std::string a(data<char>(), size());
+            const std::string b(other->data<char>(), other->size());
             return a == b;
+        }
+
+        inline bool operator==(const message_t &other) const ZMQ_NOTHROW
+        {
+            if (size () != other.size ())
+                return false;
+            const std::string a(data<char>(), size());
+            const std::string b(other.data<char>(), other.size());
+            return a == b;
+        }
+
+        inline bool operator!=(const message_t &other) const ZMQ_NOTHROW
+        {
+            return !(*this == other);
         }
 
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 1, 0)


### PR DESCRIPTION
* Added overload constructor (c++11 only) taking iteratable object.
  It would be easier to use std::string, std::array etc to construct
  a message now. Making it a draft for now in case it is too greedy
  and needs to be more specialize.
* Added equal and not euqal operator to message_t as a recommended
  and expected way of comparing objects in C++.
* deprecated C style equal method as operator== should be used instead
  (point above).
* Added message_t test covering all available message_t's constructors
  and equal, not equal operators.