### PR TITLE
Problem: Windows build broken because of multiple issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,6 @@ build:
     verbosity: normal
 
 test_script:
+    - cp Build-libzmq/bin/%configuration%/libzmq*.dll Build/bin/%configuration/
     - cd Build
     - ctest -V -C %configuration%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
 before_build:
     - appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip
     - 7z x v%ZMQ_VERSION%.zip >NUL
-    - cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -A%PLATFORM%
+    - cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM%
     - cmake --build Build-libzmq
     - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./Build-libzmq -A%PLATFORM%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,6 @@ build:
     verbosity: normal
 
 test_script:
-    - cp Build-libzmq/bin/%configuration%/libzmq*.dll Build/bin/%configuration/
+    - cp Build-libzmq/bin/%configuration%/libzmq*.dll Build/bin/%configuration%/
     - cd Build
     - ctest -V -C %configuration%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+version: build-{build}
+
+os:
+    - Visual Studio 2017
+    - Visual Studio 2015
+
+init:
+    - cmake --version
+    - msbuild /version
+
+platform:
+    - Win32
+    - x64
+
+configuration:
+    - Debug
+
+environment:
+    ZMQ_VERSION: 4.2.5
+
+before_build:
+    - appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip
+    - 7z x v%ZMQ_VERSION%.zip >NUL
+    - cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -A%PLATFORM%
+    - cmake --build Build-libzmq
+    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./Build-libzmq -A%PLATFORM%
+
+build:
+    project: Build/cppzmq.sln
+    verbosity: normal
+
+test_script:
+    - cd Build
+    - ctest -V -C %configuration%

--- a/tests/cmake/googletest.cmake
+++ b/tests/cmake/googletest.cmake
@@ -24,6 +24,11 @@ macro(fetch_googletest _download_module_path _download_root)
             ${_download_root}
         )
 
+if (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING")
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+endif()
+
     # adds the targers: gtest, gtest_main, gmock, gmock_main
     add_subdirectory(
         ${_download_root}/googletest-src

--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -4,6 +4,7 @@
 #if defined(ZMQ_CPP11) && defined(ZMQ_BUILD_DRAFT_API)
 
 #include <array>
+#include <memory>
 
 TEST(poller, create_destroy)
 {

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -73,6 +73,7 @@
     #include <chrono>
     #include <tuple>
     #include <functional>
+    #include <unordered_map>
 #endif
 
 //  Detect whether the compiler supports C++11 rvalue references.
@@ -1114,7 +1115,7 @@ namespace zmq
     private:
         void *poller_ptr;
         std::vector<zmq_poller_event_t> poller_events;
-        std::map<socket_t*, handler_t> handlers;
+        std::unordered_map<socket_t*, handler_t> handlers;
     };  // class poller_t
 #endif //  defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11) && defined(ZMQ_HAVE_POLLER)
 


### PR DESCRIPTION
Windows issues:
* missing includes files
  Solution: added missing <memory> and <unordered_map>
  Here <map> was replaced with <unordered_map> as there is no need for
  sorted map.
* googletest fails because deprecation warning causing errors.
  Solution: D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING option added.
* googletest fails because by default, new Visual Studio projects
  link the C runtimes dynamically but Google Test links them statically.
  Solution: gtest_force_shared_crt=ON option added.

Two last point should fix issue #199.

Besides adding appveyor.yml configuration to add Windows build to
CI in order to prevent accidental Windows build breakage on merge.
For now only Debug configuration as Release requires more time to figure
out.