### PR TITLE
Remove unnecessary curly bracket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ configure_package_config_file(${PROJECT_NAME}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
                               INSTALL_DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-                                 VERSION ${CPPZMQ_VERSION}}
+                                 VERSION ${CPPZMQ_VERSION}
                                  COMPATIBILITY AnyNewerVersion)
 install(EXPORT ${PROJECT_NAME}-targets
         FILE ${PROJECT_NAME}Targets.cmake


### PR DESCRIPTION
Will otherwise write `set(PACKAGE_VERSION "4.3.0}")` to `cppzmqConfigVersion.cmake`.