### PR TITLE
Problem: tests are always building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,5 +76,9 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
               DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR}/libzmq-pkg-config)
 
-enable_testing()
-add_subdirectory(tests)
+option(CPPZMQ_BUILD_TESTS "Whether or not to build the tests" ON)
+
+if (CPPZMQ_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()


### PR DESCRIPTION
Add the ability to explicitly not build tests. Option defaults to ON to keep the current behavior, but give the user the option to disable building of tests.

This option is similair to [`ZMQ_BUILD_TESTS`](https://github.com/zeromq/libzmq/blob/54fd20afdf0a5390b3e1e6a08b1f84f69d4446e4/CMakeLists.txt#L1096-L1100), but just for cppzmq.