### PR TITLE
Problem: poller_t's deprecated add might throw std::bad_function_call

### DIFF
--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -252,4 +252,19 @@ TEST(poller, poller_remove_invalid_socket_throws)
     ASSERT_EQ (1u, poller.size ());
 }
 
+TEST(poller, wait_on_added_empty_handler)
+{
+    zmq::context_t context;
+    zmq::socket_t vent{context, zmq::socket_type::push};
+    auto endpoint = loopback_ip4_binder(vent).endpoint();
+
+    zmq::socket_t sink{context, zmq::socket_type::pull};
+    ASSERT_NO_THROW(sink.connect(endpoint));
+    ASSERT_NO_THROW(vent.send("Hi"));
+
+    zmq::poller_t poller;
+    std::function<void(void)> handler;
+    ASSERT_NO_THROW(poller.add(sink, ZMQ_POLLIN, handler));
+    ASSERT_NO_THROW(poller.wait(std::chrono::milliseconds{-1}));
+}
 #endif

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1053,7 +1053,8 @@ namespace zmq
         ZMQ_DEPRECATED("from 4.3.0, use overload accepting handler_t instead")
         void add (zmq::socket_t &socket, short events, std::function<void(void)> &handler)
         {
-            add (socket, events, [&handler](short) { handler(); });
+            add (socket, events, handler ? [&handler](short) { handler(); }
+                                         : handler_t{});
         }
 
         void add (zmq::socket_t &socket, short events, handler_t handler)


### PR DESCRIPTION
Issue is reproducible in deprecated add method with empty handler
followed by wait that kicks in (covered by provided unit test).

I would prefer we remove this method completely as maintaining something
that we consider `deprecated` is unnecessary in `draft` API.