### PR TITLE
Problem: Appveyor build is slow.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,15 +15,20 @@ platform:
 configuration:
     - Debug
 
+cache:
+  - libzmq-%ZMQ_VERSION% -> appveyor.yml
+
 environment:
     ZMQ_VERSION: 4.2.5
 
 before_build:
-    - appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip
-    - 7z x v%ZMQ_VERSION%.zip >NUL
-    - cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM%
-    - cmake --build Build-libzmq
-    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./Build-libzmq -A%PLATFORM%
+    if not exist libzmq-%ZMQ_VERSION% (
+        appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip &&
+        7z x v%ZMQ_VERSION%.zip >NUL &&
+        cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
+        cmake --build Build-libzmq &&
+        cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./Build-libzmq -A%PLATFORM%
+    )
 
 build:
     project: Build/cppzmq.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,25 +17,24 @@ configuration:
 
 environment:
     ZMQ_VERSION: 4.2.5
-    ZMQ_SRC: libzmq-%ZMQ_VERSION%
-    ZMQ_BLD: %ZMQ_SRC%/build
+    ZMQ_DIR: libzmq-%ZMQ_VERSION%
 
 cache:
-    - %ZMQ_SRC% -> appveyor.yml
+    - %ZMQ_DIR% -> appveyor.yml
 
 before_build:
     - if not exist %ZMQ_SRC% (
         appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip &&
         7z x v%ZMQ_VERSION%.zip >NUL &&
-        cmake -H./%ZMQ_SRC% -B%ZMQ_BLD% -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
-        cmake --build %ZMQ_BLD%)
-    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./%ZMQ_BLD% -A%PLATFORM%
+        cmake -H./%ZMQ_DIR% -B%ZMQ_DIR%/build -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
+        cmake --build %ZMQ_DIR%/build)
+    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./%ZMQ_DIR%/build -A%PLATFORM%
 
 build:
     project: Build/cppzmq.sln
     verbosity: normal
 
 test_script:
-    - cp %ZMQ_BLD%/bin/%configuration%/libzmq*.dll Build/bin/%configuration%/
+    - cp %ZMQ_DIR%/build/bin/%configuration%/libzmq*.dll Build/bin/%configuration%/
     - cd Build
     - ctest -V -C %configuration%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ cache:
   - libzmq-%ZMQ_VERSION% -> appveyor.yml
 
 before_build:
-    if not exist libzmq-%ZMQ_VERSION% (
+    - if not exist libzmq-%ZMQ_VERSION% (
         appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip &&
         7z x v%ZMQ_VERSION%.zip >NUL &&
         cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,15 +19,14 @@ environment:
     ZMQ_VERSION: 4.2.5
 
 cache:
-  - libzmq-%ZMQ_VERSION% -> appveyor.yml
+    - libzmq-%ZMQ_VERSION% -> appveyor.yml
 
 before_build:
     - if not exist libzmq-%ZMQ_VERSION% (
         appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip &&
         7z x v%ZMQ_VERSION%.zip >NUL &&
         cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
-        cmake --build Build-libzmq
-    )
+        cmake --build Build-libzmq )
     - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./Build-libzmq -A%PLATFORM%
 
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,13 +15,13 @@ platform:
 configuration:
     - Debug
 
-cache:
-  - libzmq-%ZMQ_VERSION% -> appveyor.yml
-
 environment:
     ZMQ_VERSION: 4.2.5
 
-before_build:
+cache:
+  - libzmq-%ZMQ_VERSION% -> appveyor.yml
+
+install:
     if not exist libzmq-%ZMQ_VERSION% (
         appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip &&
         7z x v%ZMQ_VERSION%.zip >NUL &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,15 +21,13 @@ environment:
 cache:
   - libzmq-%ZMQ_VERSION% -> appveyor.yml
 
-install:
+before_build:
     if not exist libzmq-%ZMQ_VERSION% (
         appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip &&
         7z x v%ZMQ_VERSION%.zip >NUL &&
         cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
         cmake --build Build-libzmq
     )
-
-before_build:
     - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./Build-libzmq -A%PLATFORM%
 
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,11 @@ install:
         appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip &&
         7z x v%ZMQ_VERSION%.zip >NUL &&
         cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
-        cmake --build Build-libzmq &&
-        cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./Build-libzmq -A%PLATFORM%
+        cmake --build Build-libzmq
     )
+
+before_build:
+    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./Build-libzmq -A%PLATFORM%
 
 build:
     project: Build/cppzmq.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,23 +17,25 @@ configuration:
 
 environment:
     ZMQ_VERSION: 4.2.5
+    ZMQ_SRC: libzmq-%ZMQ_VERSION%
+    ZMQ_BLD: %ZMQ_SRC%/build
 
 cache:
-    - libzmq-%ZMQ_VERSION% -> appveyor.yml
+    - %ZMQ_SRC% -> appveyor.yml
 
 before_build:
-    - if not exist libzmq-%ZMQ_VERSION% (
+    - if not exist %ZMQ_SRC% (
         appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip &&
         7z x v%ZMQ_VERSION%.zip >NUL &&
-        cmake -H./libzmq-%ZMQ_VERSION% -BBuild-libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
-        cmake --build Build-libzmq )
-    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./Build-libzmq -A%PLATFORM%
+        cmake -H./%ZMQ_SRC% -B%ZMQ_BLD% -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
+        cmake --build %ZMQ_BLD%)
+    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./%ZMQ_BLD% -A%PLATFORM%
 
 build:
     project: Build/cppzmq.sln
     verbosity: normal
 
 test_script:
-    - cp Build-libzmq/bin/%configuration%/libzmq*.dll Build/bin/%configuration%/
+    - cp %ZMQ_BLD%/bin/%configuration%/libzmq*.dll Build/bin/%configuration%/
     - cd Build
     - ctest -V -C %configuration%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,25 +16,24 @@ configuration:
     - Debug
 
 environment:
-    ZMQ_VERSION: 4.2.5
-    ZMQ_DIR: libzmq-%ZMQ_VERSION%
+    ZMQ_VER: 4.2.5
 
 cache:
-    - %ZMQ_DIR% -> appveyor.yml
+    - libzmq-%ZMQ_VER% -> appveyor.yml
 
 before_build:
-    - if not exist %ZMQ_SRC% (
-        appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VERSION%.zip &&
-        7z x v%ZMQ_VERSION%.zip >NUL &&
-        cmake -H./%ZMQ_DIR% -B%ZMQ_DIR%/build -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
-        cmake --build %ZMQ_DIR%/build)
-    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./%ZMQ_DIR%/build -A%PLATFORM%
+    - if not exist libzmq-%ZMQ_VER% (
+        appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VER%.zip &&
+        7z x v%ZMQ_VER%.zip >NUL &&
+        cmake -H./libzmq-%ZMQ_VER% -Blibzmq-%ZMQ_VER%/build -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
+        cmake --build libzmq-%ZMQ_VER%/build)
+    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./libzmq-%ZMQ_VER%/build -A%PLATFORM%
 
 build:
     project: Build/cppzmq.sln
     verbosity: normal
 
 test_script:
-    - cp %ZMQ_DIR%/build/bin/%configuration%/libzmq*.dll Build/bin/%configuration%/
+    - cp libzmq-%ZMQ_VER%/build/bin/%configuration%/libzmq*.dll Build/bin/%configuration%/
     - cd Build
     - ctest -V -C %configuration%


### PR DESCRIPTION
Solution: use Appveyor caching for libzmq dependency

@bluca @sigiesec this is from appveyor website:

> Note: By default, saving cache is disabled in Pull Request builds. Use Save build cache in Pull Requests checkbox on the General tab of project settings if you need to save cache during PR builds. This setting is not exposed in YAML to prevent unauthorized cache modifications.