### PR TITLE
Problem: Appveyor Windows build does not cache googletest

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ environment:
 
 cache:
     - libzmq-%ZMQ_VER% -> appveyor.yml
+    - Build/tests/googletest -> tests/cmake/googletest-download.cmake
 
 before_build:
     - if not exist libzmq-%ZMQ_VER% (


### PR DESCRIPTION
Solution: add googletest build directory to cache and we get another ~35% speed-up