### PR TITLE
Problem: Appveyor caches way too much.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ before_build:
     - if not exist libzmq (
         appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VER%.zip &&
         7z x v%ZMQ_VER%.zip >NUL &&
-        cmake -H./libzmq-%ZMQ_VER% -Blibzmq-%ZMQ_VER%/build -CMAKE_INSTALL_PREFIX=libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
+        cmake -H./libzmq-%ZMQ_VER% -Blibzmq-%ZMQ_VER%/build -DCMAKE_INSTALL_PREFIX=libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
         cmake --build libzmq-%ZMQ_VER%/build --target install)
     - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./libzmq -A%PLATFORM%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,22 +19,22 @@ environment:
     ZMQ_VER: 4.2.5
 
 cache:
-    - libzmq-%ZMQ_VER% -> appveyor.yml
+    - libzmq -> appveyor.yml
     - Build/tests/googletest -> tests/cmake/googletest-download.cmake
 
 before_build:
-    - if not exist libzmq-%ZMQ_VER% (
+    - if not exist libzmq (
         appveyor DownloadFile https://github.com/zeromq/libzmq/archive/v%ZMQ_VER%.zip &&
         7z x v%ZMQ_VER%.zip >NUL &&
-        cmake -H./libzmq-%ZMQ_VER% -Blibzmq-%ZMQ_VER%/build -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
-        cmake --build libzmq-%ZMQ_VER%/build)
-    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./libzmq-%ZMQ_VER%/build -A%PLATFORM%
+        cmake -H./libzmq-%ZMQ_VER% -Blibzmq-%ZMQ_VER%/build -CMAKE_INSTALL_PREFIX=libzmq -DENABLE_DRAFTS=ON -DWITH_PERF_TOOL=OFF -DZMQ_BUILD_TESTS=OFF -DENABLE_CPACK=OFF -A%PLATFORM% &&
+        cmake --build libzmq-%ZMQ_VER%/build --target install)
+    - cmake -H. -BBuild -DCMAKE_PREFIX_PATH=./libzmq -A%PLATFORM%
 
 build:
     project: Build/cppzmq.sln
     verbosity: normal
 
 test_script:
-    - cp libzmq-%ZMQ_VER%/build/bin/%configuration%/libzmq*.dll Build/bin/%configuration%/
+    - cp libzmq/bin/libzmq*.dll Build/bin/%configuration%/
     - cd Build
     - ctest -V -C %configuration%


### PR DESCRIPTION
Currently appveyor caches whole libzmq directory with all sources and
build artifacts (349MB uncompressed).

Solution: install build artifacts to separate `libzmq` directory and
cache only this (~52.70MB uncompressed).
That way we can save some space on shared cache volume that is 1GB
(compressed data) now.

A build time has decreased  also~5% .