### PR TITLE
Problem: deprecated poller's add method in draft API

### DIFF
--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -265,11 +265,11 @@ TEST(poller, poller_remove_invalid_socket_throws)
 TEST(poller, wait_on_added_empty_handler)
 {
     server_client_setup s;
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW (s.client.send ("Hi"));
     zmq::poller_t poller;
-    std::function<void(void)> handler;
-    ASSERT_NO_THROW(poller.add(s.server, ZMQ_POLLIN, handler));
-    ASSERT_NO_THROW(poller.wait(std::chrono::milliseconds{-1}));
+    zmq::poller_t::handler_t handler;
+    ASSERT_NO_THROW (poller.add (s.server, ZMQ_POLLIN, handler));
+    ASSERT_NO_THROW (poller.wait (std::chrono::milliseconds {-1}));
 }
 
 TEST(poller, modify_empty_throws)

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1050,13 +1050,6 @@ namespace zmq
 
         using handler_t = std::function<void(short)>;
 
-        ZMQ_DEPRECATED("from 4.3.0, use overload accepting handler_t instead")
-        void add (zmq::socket_t &socket, short events, std::function<void(void)> &handler)
-        {
-            add (socket, events, handler ? [&handler](short) { handler(); }
-                                         : handler_t{});
-        }
-
         void add (zmq::socket_t &socket, short events, handler_t handler)
         {
             auto it = std::end (handlers);


### PR DESCRIPTION
We have a deprecated method `add` in poller that contradicts purpose of a draft
API where it can change without deprecation period.

Solution: remove the method so we do not to maintain it anymore.