### PR TITLE
Problem: googletest is also installed into install destination

### DIFF
--- a/tests/cmake/googletest.cmake
+++ b/tests/cmake/googletest.cmake
@@ -33,5 +33,6 @@ endif()
     add_subdirectory(
         ${_download_root}/googletest-src
         ${_download_root}/googletest-build
+        EXCLUDE_FROM_ALL
         )
 endmacro()


### PR DESCRIPTION
Building and installing cppzmq brings googletest build artifacts to the
installation destination as well. For example someone building cppzmq
with:
```
cmake -DCMAKE_INSTALL_PREFIX=mydest .
cmake --build --target install
```
gets googletest headers and libraries in `mydest`.

Solution: remove googletest from install target