### PR TITLE
Problem: Missing QUIET option causes a CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include (DetectCPPZMQVersion)
 
 project(cppzmq VERSION ${DETECTED_CPPZMQ_VERSION})
 
-find_package(ZeroMQ)
+find_package(ZeroMQ QUIET)
 
 # libzmq autotools install: fallback to pkg-config
 if(NOT ZeroMQ_FOUND)


### PR DESCRIPTION
When libzmq is installed via a package manager, it causes a CMake warning when building cppzmq, which can be safely ignored.

There's no behavior change with this patch, because when libzmq isn't installed it will still raise a warning ([`find_package(ZeroMQ REQUIRED)`](https://github.com/zeromq/cppzmq/blob/13bf7fdb2c0e0209b24c3fd9980e0ffa68c251b9/CMakeLists.txt#L15) is called a few lines further).