### PR TITLE
Problem: poller can segfault when modified from registered handler.

### DIFF
--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -358,8 +358,9 @@ TEST(poller, remove_from_handler)
         }));
     }
     // Clients send messages
-    for (auto & s : setup_list)
+    for (auto & s : setup_list) {
         ASSERT_NO_THROW(s.client.send("Hi"));
+    }
 
     // Wait for all servers to receive a message
     for (auto & s : setup_list) {


### PR DESCRIPTION
It is possible that a user would like to add/remove sockets from
handlers. As handlers and poll items might be removed while not
being processed yet - we have a segfault situation.
Provided unit test `remove_from_handler` demonstrates the problem.

Solution: Modify internal poll item data structure only after processing
of events is finished.

Please note that events processing path performance remains the same when there are
no modification (add/remove) to the poller (no rebuild) - main use case.

As an effect of changes `size` method has been removed as it does not
represent any meaningful information anymore. There are active and pending
(waiting for rebuild) poll items so two different sizes. User can
easily track on their side number of registered sockets if original size
information is needed.

`wait` method returns number of processed sockets now. It might be
useful information to a user for no extra cost.