### PR TITLE
Fix message using empty version variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ else (ENABLE_DRAFTS)
     set (pkg_config_defines "")
 endif (ENABLE_DRAFTS)
 
-message(STATUS "cppzmq v${CPPZMQ_VERSION}")
+message(STATUS "cppzmq v${cppzmq_VERSION}")
 
 set(CPPZMQ_HEADERS
     zmq.hpp


### PR DESCRIPTION
project(cppzmq VERSION ${DETECTED_CPPZMQ_VERSION}) will create a variable called cppzmq_VERSION instead of CPPZMQ_VERSION. This is the case under cmake v3.9.4 .