### PR TITLE
Problem: poller move operations not complete

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1099,6 +1099,16 @@ namespace zmq
             throw error_t ();
         }
 
+        bool empty () const
+        {
+            return handlers.empty ();
+        }
+
+        size_t size () const
+        {
+            return handlers.size ();
+        }
+
     private:
         std::unique_ptr<void, std::function<void(void*)>> poller_ptr
         {


### PR DESCRIPTION
Latest poller's fixes in #219 left poller's move constructor and move assignment not updated and invalid.

Solution: In order to prevent this in the future make poller default movable, which results in simpler and safer API. Extra unit tests added to cover missed use cases for move operations.
 
Additionally bringing back `size` method and added `empty` for completeness - as discussed in #219 . Unit tests updated.