### PR TITLE
Problem: poller's constructor is not default generated

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1018,12 +1018,7 @@ namespace zmq
     class poller_t
     {
     public:
-        poller_t ()
-        {
-            if (!poller_ptr)
-                throw error_t ();
-        }
-
+        poller_t () = default;
         ~poller_t () = default;
 
         poller_t(const poller_t&) = delete;
@@ -1112,7 +1107,12 @@ namespace zmq
     private:
         std::unique_ptr<void, std::function<void(void*)>> poller_ptr
         {
-            zmq_poller_new (),
+            []() {
+                auto poller_new = zmq_poller_new ();
+                if (poller_new)
+                    return poller_new;
+                throw error_t ();
+            }(),
             [](void *ptr) {
                 int rc = zmq_poller_destroy (&ptr);
                 ZMQ_ASSERT (rc == 0);


### PR DESCRIPTION
Solution: Constructor logic moved to the same place where cleanup is and
marking constructor `default`. Init/cleanup code is in one pleace making
it easier to read/maintain.