### PR TITLE
Problem: inconsistent code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,53 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+BreakBeforeBraces: Custom
+BraceWrapping: 
+    AfterClass: true
+    AfterControlStatement: false
+    AfterEnum: true 
+    AfterFunction: true 
+    AfterNamespace: true
+    AfterObjCDeclaration: true 
+    AfterStruct: true 
+    AfterUnion: true 
+    BeforeCatch: true 
+    BeforeElse: false 
+    IndentBraces: false
+
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: true
+BinPackArguments: true
+BinPackParameters: false
+AlignTrailingComments: true
+AllowShortBlocksOnASingleLine: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortFunctionsOnASingleLine: InlineOnly
+AlwaysBreakTemplateDeclarations: false
+ColumnLimit: 80
+MaxEmptyLinesToKeep: 2
+KeepEmptyLinesAtTheStartOfBlocks: false
+ContinuationIndentWidth: 2
+PointerAlignment: Right
+ReflowComments: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Always
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+
+SortIncludes: false
+
+FixNamespaceComments: false
+BreakBeforeBinaryOperators: NonAssignment
+SpaceAfterTemplateKeyword: true
+AlignAfterOpenBracket: Align
+AlignOperands: true
+BreakConstructorInitializers: AfterColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+SpaceAfterCStyleCast: true
+BreakBeforeTernaryOperators: true


### PR DESCRIPTION
Solution: copy .clang-format from `libzmq` as a starting point.

There is no need to follow exactly what libzmq does as this is header only library but it seems reasonable starting point. It would be good to stick to one style as there is a lot of activity and good ideas lately.
Build changes to follow.