### PR TITLE
Problem: poller_t::wait_all and active_poller_t::wait declare int ret…

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1091,14 +1091,14 @@ template <typename T = void> class poller_t
         }
     }
 
-    int wait_all (std::vector<zmq_poller_event_t> &poller_events,
-                  const std::chrono::microseconds timeout)
+    size_t wait_all (std::vector<zmq_poller_event_t> &poller_events,
+                     const std::chrono::microseconds timeout)
     {
         int rc = zmq_poller_wait_all (poller_ptr.get (), poller_events.data (),
                                       static_cast<int> (poller_events.size ()),
                                       static_cast<long> (timeout.count ()));
         if (rc > 0)
-            return rc;
+            return static_cast<size_t> (rc);
 
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 3)
         if (zmq_errno () == EAGAIN)

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -398,7 +398,7 @@ class active_poller_t
         base_poller.modify (socket, events);
     }
 
-    int wait (std::chrono::milliseconds timeout)
+    size_t wait (std::chrono::milliseconds timeout)
     {
         if (need_rebuild) {
             poller_events.resize (handlers.size ());
@@ -409,16 +409,13 @@ class active_poller_t
             }
             need_rebuild = false;
         }
-        const int count = base_poller.wait_all (poller_events, timeout);
-        if (count != 0) {
-            std::for_each (poller_events.begin (),
-                           poller_events.begin () + count,
-                           [](zmq_poller_event_t &event) {
-                               if (event.user_data != NULL)
-                                   (*reinterpret_cast<handler_t *> (
-                                     event.user_data)) (event.events);
-                           });
-        }
+        const auto count = base_poller.wait_all (poller_events, timeout);
+        std::for_each (poller_events.begin (), poller_events.begin () + count,
+                       [](zmq_poller_event_t &event) {
+                           if (event.user_data != NULL)
+                               (*reinterpret_cast<handler_t *> (
+                                 event.user_data)) (event.events);
+                       });
         return count;
     }
 


### PR DESCRIPTION
…urn type but actually return an element count

Solution: change return type to size_t, remove a redundant if in consequence