### PR TITLE
Problem: whitespace style too restrictive.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,14 +26,14 @@ AllowShortBlocksOnASingleLine: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortFunctionsOnASingleLine: InlineOnly
 AlwaysBreakTemplateDeclarations: false
-ColumnLimit: 80
+ColumnLimit: 85
 MaxEmptyLinesToKeep: 2
 KeepEmptyLinesAtTheStartOfBlocks: false
 ContinuationIndentWidth: 2
 PointerAlignment: Right
 ReflowComments: false
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: Always
+SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
 SpacesInAngles: false
 SpacesInParentheses: false
@@ -44,7 +44,7 @@ SortIncludes: false
 
 FixNamespaceComments: false
 BreakBeforeBinaryOperators: NonAssignment
-SpaceAfterTemplateKeyword: true
+SpaceAfterTemplateKeyword: false
 AlignAfterOpenBracket: Align
 AlignOperands: true
 BreakConstructorInitializers: AfterColon

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1,6 +1,6 @@
 #include <zmq.hpp>
 
-int main (int argc, char **argv)
+int main(int argc, char **argv)
 {
     zmq::context_t context;
     return 0;

--- a/tests/active_poller.cpp
+++ b/tests/active_poller.cpp
@@ -7,83 +7,83 @@
 #include <array>
 #include <memory>
 
-TEST (active_poller, create_destroy)
+TEST(active_poller, create_destroy)
 {
     zmq::active_poller_t active_poller;
-    ASSERT_TRUE (active_poller.empty ());
+    ASSERT_TRUE(active_poller.empty());
 }
 
-static_assert (!std::is_copy_constructible<zmq::active_poller_t>::value,
-               "active_active_poller_t should not be copy-constructible");
-static_assert (!std::is_copy_assignable<zmq::active_poller_t>::value,
-               "active_active_poller_t should not be copy-assignable");
+static_assert(!std::is_copy_constructible<zmq::active_poller_t>::value,
+              "active_active_poller_t should not be copy-constructible");
+static_assert(!std::is_copy_assignable<zmq::active_poller_t>::value,
+              "active_active_poller_t should not be copy-assignable");
 
-TEST (active_poller, move_construct_empty)
+TEST(active_poller, move_construct_empty)
 {
     zmq::active_poller_t a;
-    ASSERT_TRUE (a.empty ());
-    zmq::active_poller_t b = std::move (a);
-    ASSERT_TRUE (b.empty ());
-    ASSERT_EQ (0u, a.size ());
-    ASSERT_EQ (0u, b.size ());
+    ASSERT_TRUE(a.empty());
+    zmq::active_poller_t b = std::move(a);
+    ASSERT_TRUE(b.empty());
+    ASSERT_EQ(0u, a.size());
+    ASSERT_EQ(0u, b.size());
 }
 
-TEST (active_poller, move_assign_empty)
+TEST(active_poller, move_assign_empty)
 {
     zmq::active_poller_t a;
-    ASSERT_TRUE (a.empty ());
+    ASSERT_TRUE(a.empty());
     zmq::active_poller_t b;
-    ASSERT_TRUE (b.empty ());
-    b = std::move (a);
-    ASSERT_EQ (0u, a.size ());
-    ASSERT_EQ (0u, b.size ());
-    ASSERT_TRUE (a.empty ());
-    ASSERT_TRUE (b.empty ());
+    ASSERT_TRUE(b.empty());
+    b = std::move(a);
+    ASSERT_EQ(0u, a.size());
+    ASSERT_EQ(0u, b.size());
+    ASSERT_TRUE(a.empty());
+    ASSERT_TRUE(b.empty());
 }
 
-TEST (active_poller, move_construct_non_empty)
+TEST(active_poller, move_construct_non_empty)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
 
     zmq::active_poller_t a;
-    a.add (socket, ZMQ_POLLIN, [](short) {});
-    ASSERT_FALSE (a.empty ());
-    ASSERT_EQ (1u, a.size ());
-    zmq::active_poller_t b = std::move (a);
-    ASSERT_TRUE (a.empty ());
-    ASSERT_EQ (0u, a.size ());
-    ASSERT_FALSE (b.empty ());
-    ASSERT_EQ (1u, b.size ());
+    a.add(socket, ZMQ_POLLIN, [](short) {});
+    ASSERT_FALSE(a.empty());
+    ASSERT_EQ(1u, a.size());
+    zmq::active_poller_t b = std::move(a);
+    ASSERT_TRUE(a.empty());
+    ASSERT_EQ(0u, a.size());
+    ASSERT_FALSE(b.empty());
+    ASSERT_EQ(1u, b.size());
 }
 
-TEST (active_poller, move_assign_non_empty)
+TEST(active_poller, move_assign_non_empty)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
 
     zmq::active_poller_t a;
-    a.add (socket, ZMQ_POLLIN, [](short) {});
-    ASSERT_FALSE (a.empty ());
-    ASSERT_EQ (1u, a.size ());
+    a.add(socket, ZMQ_POLLIN, [](short) {});
+    ASSERT_FALSE(a.empty());
+    ASSERT_EQ(1u, a.size());
     zmq::active_poller_t b;
-    b = std::move (a);
-    ASSERT_TRUE (a.empty ());
-    ASSERT_EQ (0u, a.size ());
-    ASSERT_FALSE (b.empty ());
-    ASSERT_EQ (1u, b.size ());
+    b = std::move(a);
+    ASSERT_TRUE(a.empty());
+    ASSERT_EQ(0u, a.size());
+    ASSERT_FALSE(b.empty());
+    ASSERT_EQ(1u, b.size());
 }
 
-TEST (active_poller, add_handler)
+TEST(active_poller, add_handler)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
     zmq::active_poller_t::handler_t handler;
-    ASSERT_NO_THROW (active_poller.add (socket, ZMQ_POLLIN, handler));
+    ASSERT_NO_THROW(active_poller.add(socket, ZMQ_POLLIN, handler));
 }
 
-TEST (active_poller, add_handler_invalid_events_type)
+TEST(active_poller, add_handler_invalid_events_type)
 {
     /// \todo is it good that this is accepted? should probably already be
     ///   checked by zmq_poller_add/modify in libzmq:
@@ -93,56 +93,54 @@ TEST (active_poller, add_handler_invalid_events_type)
     zmq::active_poller_t active_poller;
     zmq::active_poller_t::handler_t handler;
     short invalid_events_type = 2 << 10;
-    ASSERT_NO_THROW (active_poller.add (socket, invalid_events_type, handler));
-    ASSERT_FALSE (active_poller.empty ());
-    ASSERT_EQ (1u, active_poller.size ());
+    ASSERT_NO_THROW(active_poller.add(socket, invalid_events_type, handler));
+    ASSERT_FALSE(active_poller.empty());
+    ASSERT_EQ(1u, active_poller.size());
 }
 
-TEST (active_poller, add_handler_twice_throws)
+TEST(active_poller, add_handler_twice_throws)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
     zmq::active_poller_t::handler_t handler;
-    active_poller.add (socket, ZMQ_POLLIN, handler);
+    active_poller.add(socket, ZMQ_POLLIN, handler);
     /// \todo the actual error code should be checked
-    ASSERT_THROW (active_poller.add (socket, ZMQ_POLLIN, handler),
-                  zmq::error_t);
+    ASSERT_THROW(active_poller.add(socket, ZMQ_POLLIN, handler), zmq::error_t);
 }
 
-TEST (active_poller, wait_with_no_handlers_throws)
+TEST(active_poller, wait_with_no_handlers_throws)
 {
     zmq::active_poller_t active_poller;
     /// \todo the actual error code should be checked
-    ASSERT_THROW (active_poller.wait (std::chrono::milliseconds{10}),
-                  zmq::error_t);
+    ASSERT_THROW(active_poller.wait(std::chrono::milliseconds{10}), zmq::error_t);
 }
 
-TEST (active_poller, remove_unregistered_throws)
+TEST(active_poller, remove_unregistered_throws)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
     /// \todo the actual error code should be checked
-    ASSERT_THROW (active_poller.remove (socket), zmq::error_t);
+    ASSERT_THROW(active_poller.remove(socket), zmq::error_t);
 }
 
-TEST (active_poller, remove_registered_empty)
+TEST(active_poller, remove_registered_empty)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
-    active_poller.add (socket, ZMQ_POLLIN, zmq::active_poller_t::handler_t{});
-    ASSERT_NO_THROW (active_poller.remove (socket));
+    active_poller.add(socket, ZMQ_POLLIN, zmq::active_poller_t::handler_t{});
+    ASSERT_NO_THROW(active_poller.remove(socket));
 }
 
-TEST (active_poller, remove_registered_non_empty)
+TEST(active_poller, remove_registered_non_empty)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
-    active_poller.add (socket, ZMQ_POLLIN, [](short) {});
-    ASSERT_NO_THROW (active_poller.remove (socket));
+    active_poller.add(socket, ZMQ_POLLIN, [](short) {});
+    ASSERT_NO_THROW(active_poller.remove(socket));
 }
 
 namespace
@@ -155,26 +153,25 @@ struct server_client_setup : common_server_client_setup
 };
 }
 
-TEST (active_poller, poll_basic)
+TEST(active_poller, poll_basic)
 {
     server_client_setup s;
 
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
 
     zmq::active_poller_t active_poller;
     bool message_received = false;
-    zmq::active_poller_t::handler_t handler =
-      [&message_received](short events) {
-          ASSERT_TRUE (0 != (events & ZMQ_POLLIN));
-          message_received = true;
-      };
-    ASSERT_NO_THROW (active_poller.add (s.server, ZMQ_POLLIN, handler));
-    ASSERT_EQ (1, active_poller.wait (std::chrono::milliseconds{-1}));
-    ASSERT_TRUE (message_received);
+    zmq::active_poller_t::handler_t handler = [&message_received](short events) {
+        ASSERT_TRUE(0 != (events & ZMQ_POLLIN));
+        message_received = true;
+    };
+    ASSERT_NO_THROW(active_poller.add(s.server, ZMQ_POLLIN, handler));
+    ASSERT_EQ(1, active_poller.wait(std::chrono::milliseconds{-1}));
+    ASSERT_TRUE(message_received);
 }
 
 /// \todo this contains multiple test cases that should be split up
-TEST (active_poller, client_server)
+TEST(active_poller, client_server)
 {
     const std::string send_msg = "Hi";
 
@@ -187,127 +184,125 @@ TEST (active_poller, client_server)
     zmq::active_poller_t::handler_t handler = [&](short e) {
         if (0 != (e & ZMQ_POLLIN)) {
             zmq::message_t zmq_msg;
-            ASSERT_NO_THROW (s.server.recv (&zmq_msg)); // get message
-            std::string recv_msg (zmq_msg.data<char> (), zmq_msg.size ());
-            ASSERT_EQ (send_msg, recv_msg);
+            ASSERT_NO_THROW(s.server.recv(&zmq_msg)); // get message
+            std::string recv_msg(zmq_msg.data<char>(), zmq_msg.size());
+            ASSERT_EQ(send_msg, recv_msg);
         } else if (0 != (e & ~ZMQ_POLLOUT)) {
-            ASSERT_TRUE (false) << "Unexpected event type " << events;
+            ASSERT_TRUE(false) << "Unexpected event type " << events;
         }
         events = e;
     };
 
-    ASSERT_NO_THROW (active_poller.add (s.server, ZMQ_POLLIN, handler));
+    ASSERT_NO_THROW(active_poller.add(s.server, ZMQ_POLLIN, handler));
 
     // client sends message
-    ASSERT_NO_THROW (s.client.send (send_msg));
+    ASSERT_NO_THROW(s.client.send(send_msg));
 
-    ASSERT_EQ (1, active_poller.wait (std::chrono::milliseconds{-1}));
-    ASSERT_EQ (events, ZMQ_POLLIN);
+    ASSERT_EQ(1, active_poller.wait(std::chrono::milliseconds{-1}));
+    ASSERT_EQ(events, ZMQ_POLLIN);
 
     // Re-add server socket with pollout flag
-    ASSERT_NO_THROW (active_poller.remove (s.server));
-    ASSERT_NO_THROW (
-      active_poller.add (s.server, ZMQ_POLLIN | ZMQ_POLLOUT, handler));
-    ASSERT_EQ (1, active_poller.wait (std::chrono::milliseconds{-1}));
-    ASSERT_EQ (events, ZMQ_POLLOUT);
+    ASSERT_NO_THROW(active_poller.remove(s.server));
+    ASSERT_NO_THROW(active_poller.add(s.server, ZMQ_POLLIN | ZMQ_POLLOUT, handler));
+    ASSERT_EQ(1, active_poller.wait(std::chrono::milliseconds{-1}));
+    ASSERT_EQ(events, ZMQ_POLLOUT);
 }
 
-TEST (active_poller, add_invalid_socket_throws)
+TEST(active_poller, add_invalid_socket_throws)
 {
     zmq::context_t context;
     zmq::active_poller_t active_poller;
     zmq::socket_t a{context, zmq::socket_type::router};
-    zmq::socket_t b{std::move (a)};
-    ASSERT_THROW (
-      active_poller.add (a, ZMQ_POLLIN, zmq::active_poller_t::handler_t{}),
-      zmq::error_t);
+    zmq::socket_t b{std::move(a)};
+    ASSERT_THROW(active_poller.add(a, ZMQ_POLLIN, zmq::active_poller_t::handler_t{}),
+                 zmq::error_t);
 }
 
-TEST (active_poller, remove_invalid_socket_throws)
+TEST(active_poller, remove_invalid_socket_throws)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
-    ASSERT_NO_THROW (active_poller.add (socket, ZMQ_POLLIN,
-                                        zmq::active_poller_t::handler_t{}));
-    ASSERT_EQ (1u, active_poller.size ());
+    ASSERT_NO_THROW(
+      active_poller.add(socket, ZMQ_POLLIN, zmq::active_poller_t::handler_t{}));
+    ASSERT_EQ(1u, active_poller.size());
     std::vector<zmq::socket_t> sockets;
-    sockets.emplace_back (std::move (socket));
-    ASSERT_THROW (active_poller.remove (socket), zmq::error_t);
-    ASSERT_EQ (1u, active_poller.size ());
+    sockets.emplace_back(std::move(socket));
+    ASSERT_THROW(active_poller.remove(socket), zmq::error_t);
+    ASSERT_EQ(1u, active_poller.size());
 }
 
-TEST (active_poller, wait_on_added_empty_handler)
+TEST(active_poller, wait_on_added_empty_handler)
 {
     server_client_setup s;
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
     zmq::active_poller_t active_poller;
     zmq::active_poller_t::handler_t handler;
-    ASSERT_NO_THROW (active_poller.add (s.server, ZMQ_POLLIN, handler));
-    ASSERT_NO_THROW (active_poller.wait (std::chrono::milliseconds{-1}));
+    ASSERT_NO_THROW(active_poller.add(s.server, ZMQ_POLLIN, handler));
+    ASSERT_NO_THROW(active_poller.wait(std::chrono::milliseconds{-1}));
 }
 
-TEST (active_poller, modify_empty_throws)
+TEST(active_poller, modify_empty_throws)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
-    ASSERT_THROW (active_poller.modify (socket, ZMQ_POLLIN), zmq::error_t);
+    ASSERT_THROW(active_poller.modify(socket, ZMQ_POLLIN), zmq::error_t);
 }
 
-TEST (active_poller, modify_invalid_socket_throws)
+TEST(active_poller, modify_invalid_socket_throws)
 {
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
-    zmq::socket_t b{std::move (a)};
+    zmq::socket_t b{std::move(a)};
     zmq::active_poller_t active_poller;
-    ASSERT_THROW (active_poller.modify (a, ZMQ_POLLIN), zmq::error_t);
+    ASSERT_THROW(active_poller.modify(a, ZMQ_POLLIN), zmq::error_t);
 }
 
-TEST (active_poller, modify_not_added_throws)
+TEST(active_poller, modify_not_added_throws)
 {
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::socket_t b{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
-    ASSERT_NO_THROW (
-      active_poller.add (a, ZMQ_POLLIN, zmq::active_poller_t::handler_t{}));
-    ASSERT_THROW (active_poller.modify (b, ZMQ_POLLIN), zmq::error_t);
+    ASSERT_NO_THROW(
+      active_poller.add(a, ZMQ_POLLIN, zmq::active_poller_t::handler_t{}));
+    ASSERT_THROW(active_poller.modify(b, ZMQ_POLLIN), zmq::error_t);
 }
 
-TEST (active_poller, modify_simple)
+TEST(active_poller, modify_simple)
 {
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
-    ASSERT_NO_THROW (
-      active_poller.add (a, ZMQ_POLLIN, zmq::active_poller_t::handler_t{}));
-    ASSERT_NO_THROW (active_poller.modify (a, ZMQ_POLLIN | ZMQ_POLLOUT));
+    ASSERT_NO_THROW(
+      active_poller.add(a, ZMQ_POLLIN, zmq::active_poller_t::handler_t{}));
+    ASSERT_NO_THROW(active_poller.modify(a, ZMQ_POLLIN | ZMQ_POLLOUT));
 }
 
-TEST (active_poller, poll_client_server)
+TEST(active_poller, poll_client_server)
 {
     // Setup server and client
     server_client_setup s;
 
     // Setup active_poller
     zmq::active_poller_t active_poller;
-    ASSERT_NO_THROW (active_poller.add (s.server, ZMQ_POLLIN, s.handler));
+    ASSERT_NO_THROW(active_poller.add(s.server, ZMQ_POLLIN, s.handler));
 
     // client sends message
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
 
     // wait for message and verify events
-    ASSERT_NO_THROW (active_poller.wait (std::chrono::milliseconds{500}));
-    ASSERT_EQ (s.events, ZMQ_POLLIN);
+    ASSERT_NO_THROW(active_poller.wait(std::chrono::milliseconds{500}));
+    ASSERT_EQ(s.events, ZMQ_POLLIN);
 
     // Modify server socket with pollout flag
-    ASSERT_NO_THROW (active_poller.modify (s.server, ZMQ_POLLIN | ZMQ_POLLOUT));
-    ASSERT_EQ (1, active_poller.wait (std::chrono::milliseconds{500}));
-    ASSERT_EQ (s.events, ZMQ_POLLIN | ZMQ_POLLOUT);
+    ASSERT_NO_THROW(active_poller.modify(s.server, ZMQ_POLLIN | ZMQ_POLLOUT));
+    ASSERT_EQ(1, active_poller.wait(std::chrono::milliseconds{500}));
+    ASSERT_EQ(s.events, ZMQ_POLLIN | ZMQ_POLLOUT);
 }
 
-TEST (active_poller, wait_one_return)
+TEST(active_poller, wait_one_return)
 {
     // Setup server and client
     server_client_setup s;
@@ -316,106 +311,105 @@ TEST (active_poller, wait_one_return)
 
     // Setup active_poller
     zmq::active_poller_t active_poller;
-    ASSERT_NO_THROW (
-      active_poller.add (s.server, ZMQ_POLLIN, [&count](short) { ++count; }));
+    ASSERT_NO_THROW(
+      active_poller.add(s.server, ZMQ_POLLIN, [&count](short) { ++count; }));
 
     // client sends message
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
 
     // wait for message and verify events
-    ASSERT_EQ (1, active_poller.wait (std::chrono::milliseconds{500}));
-    ASSERT_EQ (1u, count);
+    ASSERT_EQ(1, active_poller.wait(std::chrono::milliseconds{500}));
+    ASSERT_EQ(1u, count);
 }
 
-TEST (active_poller, wait_on_move_constructed_active_poller)
+TEST(active_poller, wait_on_move_constructed_active_poller)
 {
     server_client_setup s;
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
     zmq::active_poller_t a;
     zmq::active_poller_t::handler_t handler;
-    ASSERT_NO_THROW (a.add (s.server, ZMQ_POLLIN, handler));
-    zmq::active_poller_t b{std::move (a)};
-    ASSERT_EQ (1u, b.size ());
+    ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, handler));
+    zmq::active_poller_t b{std::move(a)};
+    ASSERT_EQ(1u, b.size());
     /// \todo the actual error code should be checked
-    ASSERT_THROW (a.wait (std::chrono::milliseconds{10}), zmq::error_t);
-    ASSERT_TRUE (b.wait (std::chrono::milliseconds{-1}));
+    ASSERT_THROW(a.wait(std::chrono::milliseconds{10}), zmq::error_t);
+    ASSERT_TRUE(b.wait(std::chrono::milliseconds{-1}));
 }
 
-TEST (active_poller, wait_on_move_assigned_active_poller)
+TEST(active_poller, wait_on_move_assigned_active_poller)
 {
     server_client_setup s;
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
     zmq::active_poller_t a;
     zmq::active_poller_t::handler_t handler;
-    ASSERT_NO_THROW (a.add (s.server, ZMQ_POLLIN, handler));
+    ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, handler));
     zmq::active_poller_t b;
-    b = {std::move (a)};
-    ASSERT_EQ (1u, b.size ());
+    b = {std::move(a)};
+    ASSERT_EQ(1u, b.size());
     /// \todo the actual error code should be checked
-    ASSERT_THROW (a.wait (std::chrono::milliseconds{10}), zmq::error_t);
-    ASSERT_TRUE (b.wait (std::chrono::milliseconds{-1}));
+    ASSERT_THROW(a.wait(std::chrono::milliseconds{10}), zmq::error_t);
+    ASSERT_TRUE(b.wait(std::chrono::milliseconds{-1}));
 }
 
-TEST (active_poller, received_on_move_constructed_active_poller)
+TEST(active_poller, received_on_move_constructed_active_poller)
 {
     // Setup server and client
     server_client_setup s;
     int count = 0;
     // Setup active_poller a
     zmq::active_poller_t a;
-    ASSERT_NO_THROW (
-      a.add (s.server, ZMQ_POLLIN, [&count](short) { ++count; }));
+    ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, [&count](short) { ++count; }));
     // client sends message
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
     // wait for message and verify it is received
-    ASSERT_EQ (1, a.wait (std::chrono::milliseconds{500}));
-    ASSERT_EQ (1u, count);
+    ASSERT_EQ(1, a.wait(std::chrono::milliseconds{500}));
+    ASSERT_EQ(1u, count);
     // Move construct active_poller b
-    zmq::active_poller_t b{std::move (a)};
+    zmq::active_poller_t b{std::move(a)};
     // client sends message again
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
     // wait for message and verify it is received
-    ASSERT_EQ (1, b.wait (std::chrono::milliseconds{500}));
-    ASSERT_EQ (2u, count);
+    ASSERT_EQ(1, b.wait(std::chrono::milliseconds{500}));
+    ASSERT_EQ(2u, count);
 }
 
 
-TEST (active_poller, remove_from_handler)
+TEST(active_poller, remove_from_handler)
 {
     constexpr auto ITER_NO = 10;
 
     // Setup servers and clients
     std::vector<server_client_setup> setup_list;
     for (auto i = 0; i < ITER_NO; ++i)
-        setup_list.emplace_back (server_client_setup{});
+        setup_list.emplace_back(server_client_setup{});
 
     // Setup active_poller
     zmq::active_poller_t active_poller;
     int count = 0;
     for (auto i = 0; i < ITER_NO; ++i) {
-        ASSERT_NO_THROW (active_poller.add (
-          setup_list[i].server, ZMQ_POLLIN, [&, i](short events) {
-              ASSERT_EQ (events, ZMQ_POLLIN);
-              active_poller.remove (setup_list[ITER_NO - i - 1].server);
-              ASSERT_EQ (ITER_NO - i - 1, active_poller.size ());
+        ASSERT_NO_THROW(
+          active_poller.add(setup_list[i].server, ZMQ_POLLIN, [&, i](short events) {
+              ASSERT_EQ(events, ZMQ_POLLIN);
+              active_poller.remove(setup_list[ITER_NO - i - 1].server);
+              ASSERT_EQ(ITER_NO - i - 1, active_poller.size());
           }));
         ++count;
     }
-    ASSERT_EQ (ITER_NO, active_poller.size ());
+    ASSERT_EQ(ITER_NO, active_poller.size());
     // Clients send messages
     for (auto &s : setup_list) {
-        ASSERT_NO_THROW (s.client.send ("Hi"));
+        ASSERT_NO_THROW(s.client.send("Hi"));
     }
 
     // Wait for all servers to receive a message
     for (auto &s : setup_list) {
         zmq::pollitem_t items[] = {{s.server, 0, ZMQ_POLLIN, 0}};
-        zmq::poll (&items[0], 1);
+        zmq::poll(&items[0], 1);
     }
 
     // Fire all handlers in one wait
-    ASSERT_EQ (ITER_NO, active_poller.wait (std::chrono::milliseconds{-1}));
-    ASSERT_EQ (ITER_NO, count);
+    ASSERT_EQ(ITER_NO, active_poller.wait(std::chrono::milliseconds{-1}));
+    ASSERT_EQ(ITER_NO, count);
 }
 
 #endif

--- a/tests/context.cpp
+++ b/tests/context.cpp
@@ -1,15 +1,15 @@
 #include <gtest/gtest.h>
 #include <zmq.hpp>
 
-TEST (context, create_default_destroy)
+TEST(context, create_default_destroy)
 {
     zmq::context_t context;
 }
 
-TEST (context, create_close)
+TEST(context, create_close)
 {
     zmq::context_t context;
-    context.close ();
+    context.close();
 
-    ASSERT_EQ (NULL, (void *) context);
+    ASSERT_EQ(NULL, (void *) context);
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 
-int main (int argc, char **argv)
+int main(int argc, char **argv)
 {
-    ::testing::InitGoogleTest (&argc, argv);
-    return RUN_ALL_TESTS ();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -2,119 +2,119 @@
 #include <zmq.hpp>
 
 #if defined(ZMQ_CPP11)
-static_assert (!std::is_copy_constructible<zmq::message_t>::value,
-               "message_t should not be copy-constructible");
-static_assert (!std::is_copy_assignable<zmq::message_t>::value,
-               "message_t should not be copy-assignable");
+static_assert(!std::is_copy_constructible<zmq::message_t>::value,
+              "message_t should not be copy-constructible");
+static_assert(!std::is_copy_assignable<zmq::message_t>::value,
+              "message_t should not be copy-assignable");
 #endif
 
-TEST (message, constructor_default)
+TEST(message, constructor_default)
 {
     const zmq::message_t message;
-    ASSERT_EQ (0u, message.size ());
+    ASSERT_EQ(0u, message.size());
 }
 
 const char *const data = "Hi";
 
-TEST (message, constructor_iterators)
+TEST(message, constructor_iterators)
 {
-    const std::string hi (data);
-    const zmq::message_t hi_msg (hi.begin (), hi.end ());
-    ASSERT_EQ (2u, hi_msg.size ());
-    ASSERT_EQ (0, memcmp (data, hi_msg.data (), 2));
+    const std::string hi(data);
+    const zmq::message_t hi_msg(hi.begin(), hi.end());
+    ASSERT_EQ(2u, hi_msg.size());
+    ASSERT_EQ(0, memcmp(data, hi_msg.data(), 2));
 }
 
-TEST (message, constructor_pointer_size)
+TEST(message, constructor_pointer_size)
 {
-    const std::string hi (data);
-    const zmq::message_t hi_msg (hi.data (), hi.size ());
-    ASSERT_EQ (2u, hi_msg.size ());
-    ASSERT_EQ (0, memcmp (data, hi_msg.data (), 2));
+    const std::string hi(data);
+    const zmq::message_t hi_msg(hi.data(), hi.size());
+    ASSERT_EQ(2u, hi_msg.size());
+    ASSERT_EQ(0, memcmp(data, hi_msg.data(), 2));
 }
 
-TEST (message, constructor_char_array)
+TEST(message, constructor_char_array)
 {
-    const zmq::message_t hi_msg (data, strlen (data));
-    ASSERT_EQ (2u, hi_msg.size ());
-    ASSERT_EQ (0, memcmp (data, hi_msg.data (), 2));
+    const zmq::message_t hi_msg(data, strlen(data));
+    ASSERT_EQ(2u, hi_msg.size());
+    ASSERT_EQ(0, memcmp(data, hi_msg.data(), 2));
 }
 
 #if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)
-TEST (message, constructor_container)
+TEST(message, constructor_container)
 {
-    const std::string hi (data);
-    zmq::message_t hi_msg (hi);
-    ASSERT_EQ (2u, hi_msg.size ());
-    ASSERT_EQ (0, memcmp (data, hi_msg.data (), 2));
+    const std::string hi(data);
+    zmq::message_t hi_msg(hi);
+    ASSERT_EQ(2u, hi_msg.size());
+    ASSERT_EQ(0, memcmp(data, hi_msg.data(), 2));
 }
 #endif
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-TEST (message, constructor_move)
+TEST(message, constructor_move)
 {
-    zmq::message_t hi_msg (zmq::message_t (data, strlen (data)));
+    zmq::message_t hi_msg(zmq::message_t(data, strlen(data)));
 }
 
-TEST (message, assign_move_empty_before)
+TEST(message, assign_move_empty_before)
 {
     zmq::message_t hi_msg;
-    hi_msg = zmq::message_t (data, strlen (data));
-    ASSERT_EQ (2u, hi_msg.size ());
-    ASSERT_EQ (0, memcmp (data, hi_msg.data (), 2));
+    hi_msg = zmq::message_t(data, strlen(data));
+    ASSERT_EQ(2u, hi_msg.size());
+    ASSERT_EQ(0, memcmp(data, hi_msg.data(), 2));
 }
 
-TEST (message, assign_move_empty_after)
+TEST(message, assign_move_empty_after)
 {
-    zmq::message_t hi_msg (data, strlen (data));
-    hi_msg = zmq::message_t ();
-    ASSERT_EQ (0u, hi_msg.size ());
+    zmq::message_t hi_msg(data, strlen(data));
+    hi_msg = zmq::message_t();
+    ASSERT_EQ(0u, hi_msg.size());
 }
 
-TEST (message, assign_move_empty_before_and_after)
+TEST(message, assign_move_empty_before_and_after)
 {
     zmq::message_t hi_msg;
-    hi_msg = zmq::message_t ();
-    ASSERT_EQ (0u, hi_msg.size ());
+    hi_msg = zmq::message_t();
+    ASSERT_EQ(0u, hi_msg.size());
 }
 #endif
 
-TEST (message, equality_self)
+TEST(message, equality_self)
 {
-    const zmq::message_t hi_msg (data, strlen (data));
-    ASSERT_EQ (hi_msg, hi_msg);
+    const zmq::message_t hi_msg(data, strlen(data));
+    ASSERT_EQ(hi_msg, hi_msg);
 }
 
-TEST (message, equality_equal)
+TEST(message, equality_equal)
 {
-    const zmq::message_t hi_msg_a (data, strlen (data));
-    const zmq::message_t hi_msg_b (data, strlen (data));
-    ASSERT_EQ (hi_msg_a, hi_msg_b);
+    const zmq::message_t hi_msg_a(data, strlen(data));
+    const zmq::message_t hi_msg_b(data, strlen(data));
+    ASSERT_EQ(hi_msg_a, hi_msg_b);
 }
 
-TEST (message, equality_equal_empty)
+TEST(message, equality_equal_empty)
 {
     const zmq::message_t msg_a;
     const zmq::message_t msg_b;
-    ASSERT_EQ (msg_a, msg_b);
+    ASSERT_EQ(msg_a, msg_b);
 }
 
-TEST (message, equality_non_equal)
+TEST(message, equality_non_equal)
 {
-    const zmq::message_t msg_a ("Hi", 2);
-    const zmq::message_t msg_b ("Hello", 5);
-    ASSERT_NE (msg_a, msg_b);
+    const zmq::message_t msg_a("Hi", 2);
+    const zmq::message_t msg_b("Hello", 5);
+    ASSERT_NE(msg_a, msg_b);
 }
 
-TEST (message, equality_non_equal_rhs_empty)
+TEST(message, equality_non_equal_rhs_empty)
 {
-    const zmq::message_t msg_a ("Hi", 2);
+    const zmq::message_t msg_a("Hi", 2);
     const zmq::message_t msg_b;
-    ASSERT_NE (msg_a, msg_b);
+    ASSERT_NE(msg_a, msg_b);
 }
 
-TEST (message, equality_non_equal_lhs_empty)
+TEST(message, equality_non_equal_lhs_empty)
 {
     const zmq::message_t msg_a;
-    const zmq::message_t msg_b ("Hi", 2);
-    ASSERT_NE (msg_a, msg_b);
+    const zmq::message_t msg_b("Hi", 2);
+    ASSERT_NE(msg_a, msg_b);
 }

--- a/tests/multipart.cpp
+++ b/tests/multipart.cpp
@@ -4,7 +4,7 @@
 #ifdef ZMQ_HAS_RVALUE_REFS
 /// \todo split this up into separate test cases
 ///
-TEST (multipart, legacy_test)
+TEST(multipart, legacy_test)
 {
     using namespace zmq;
 
@@ -16,158 +16,158 @@ TEST (multipart, legacy_test)
     message_t msg;
 
     // Create two PAIR sockets and connect over inproc
-    context_t context (1);
-    socket_t output (context, ZMQ_PAIR);
-    socket_t input (context, ZMQ_PAIR);
-    output.bind ("inproc://multipart.test");
-    input.connect ("inproc://multipart.test");
+    context_t context(1);
+    socket_t output(context, ZMQ_PAIR);
+    socket_t input(context, ZMQ_PAIR);
+    output.bind("inproc://multipart.test");
+    input.connect("inproc://multipart.test");
 
     // Test send and receive of single-frame message
     multipart_t multipart;
-    assert (multipart.empty ());
+    assert(multipart.empty());
 
-    multipart.push (message_t ("Hello", 5));
-    assert (multipart.size () == 1);
+    multipart.push(message_t("Hello", 5));
+    assert(multipart.size() == 1);
 
-    ok = multipart.send (output);
-    assert (multipart.empty ());
-    assert (ok);
+    ok = multipart.send(output);
+    assert(multipart.empty());
+    assert(ok);
 
-    ok = multipart.recv (input);
-    assert (multipart.size () == 1);
-    assert (ok);
+    ok = multipart.recv(input);
+    assert(multipart.size() == 1);
+    assert(ok);
 
-    msg = multipart.pop ();
-    assert (multipart.empty ());
-    assert (std::string (msg.data<char> (), msg.size ()) == "Hello");
+    msg = multipart.pop();
+    assert(multipart.empty());
+    assert(std::string(msg.data<char>(), msg.size()) == "Hello");
 
     // Test send and receive of multi-frame message
-    multipart.addstr ("A");
-    multipart.addstr ("BB");
-    multipart.addstr ("CCC");
-    assert (multipart.size () == 3);
+    multipart.addstr("A");
+    multipart.addstr("BB");
+    multipart.addstr("CCC");
+    assert(multipart.size() == 3);
 
-    multipart_t copy = multipart.clone ();
-    assert (copy.size () == 3);
+    multipart_t copy = multipart.clone();
+    assert(copy.size() == 3);
 
-    ok = copy.send (output);
-    assert (copy.empty ());
-    assert (ok);
+    ok = copy.send(output);
+    assert(copy.empty());
+    assert(ok);
 
-    ok = copy.recv (input);
-    assert (copy.size () == 3);
-    assert (ok);
-    assert (copy.equal (&multipart));
+    ok = copy.recv(input);
+    assert(copy.size() == 3);
+    assert(ok);
+    assert(copy.equal(&multipart));
 
-    multipart.clear ();
-    assert (multipart.empty ());
+    multipart.clear();
+    assert(multipart.empty());
 
     // Test message frame manipulation
-    multipart.add (message_t ("Frame5", 6));
-    multipart.addstr ("Frame6");
-    multipart.addstr ("Frame7");
-    multipart.addtyp (8.0f);
-    multipart.addmem ("Frame9", 6);
-    multipart.push (message_t ("Frame4", 6));
-    multipart.pushstr ("Frame3");
-    multipart.pushstr ("Frame2");
-    multipart.pushtyp (1.0f);
-    multipart.pushmem ("Frame0", 6);
-    assert (multipart.size () == 10);
+    multipart.add(message_t("Frame5", 6));
+    multipart.addstr("Frame6");
+    multipart.addstr("Frame7");
+    multipart.addtyp(8.0f);
+    multipart.addmem("Frame9", 6);
+    multipart.push(message_t("Frame4", 6));
+    multipart.pushstr("Frame3");
+    multipart.pushstr("Frame2");
+    multipart.pushtyp(1.0f);
+    multipart.pushmem("Frame0", 6);
+    assert(multipart.size() == 10);
 
-    msg = multipart.remove ();
-    assert (multipart.size () == 9);
-    assert (std::string (msg.data<char> (), msg.size ()) == "Frame9");
+    msg = multipart.remove();
+    assert(multipart.size() == 9);
+    assert(std::string(msg.data<char>(), msg.size()) == "Frame9");
 
-    msg = multipart.pop ();
-    assert (multipart.size () == 8);
-    assert (std::string (msg.data<char> (), msg.size ()) == "Frame0");
+    msg = multipart.pop();
+    assert(multipart.size() == 8);
+    assert(std::string(msg.data<char>(), msg.size()) == "Frame0");
 
-    num = multipart.poptyp<float> ();
-    assert (multipart.size () == 7);
-    assert (num == 1.0f);
+    num = multipart.poptyp<float>();
+    assert(multipart.size() == 7);
+    assert(num == 1.0f);
 
-    str = multipart.popstr ();
-    assert (multipart.size () == 6);
-    assert (str == "Frame2");
+    str = multipart.popstr();
+    assert(multipart.size() == 6);
+    assert(str == "Frame2");
 
-    str = multipart.popstr ();
-    assert (multipart.size () == 5);
-    assert (str == "Frame3");
+    str = multipart.popstr();
+    assert(multipart.size() == 5);
+    assert(str == "Frame3");
 
-    str = multipart.popstr ();
-    assert (multipart.size () == 4);
-    assert (str == "Frame4");
+    str = multipart.popstr();
+    assert(multipart.size() == 4);
+    assert(str == "Frame4");
 
-    str = multipart.popstr ();
-    assert (multipart.size () == 3);
-    assert (str == "Frame5");
+    str = multipart.popstr();
+    assert(multipart.size() == 3);
+    assert(str == "Frame5");
 
-    str = multipart.popstr ();
-    assert (multipart.size () == 2);
-    assert (str == "Frame6");
+    str = multipart.popstr();
+    assert(multipart.size() == 2);
+    assert(str == "Frame6");
 
-    str = multipart.popstr ();
-    assert (multipart.size () == 1);
-    assert (str == "Frame7");
+    str = multipart.popstr();
+    assert(multipart.size() == 1);
+    assert(str == "Frame7");
 
-    num = multipart.poptyp<float> ();
-    assert (multipart.empty ());
-    assert (num == 8.0f);
+    num = multipart.poptyp<float>();
+    assert(multipart.empty());
+    assert(num == 8.0f);
 
     // Test message constructors and concatenation
-    multipart_t head ("One", 3);
-    head.addstr ("Two");
-    assert (head.size () == 2);
+    multipart_t head("One", 3);
+    head.addstr("Two");
+    assert(head.size() == 2);
 
-    multipart_t tail (std::string ("One-hundred"));
-    tail.pushstr ("Ninety-nine");
-    assert (tail.size () == 2);
+    multipart_t tail(std::string("One-hundred"));
+    tail.pushstr("Ninety-nine");
+    assert(tail.size() == 2);
 
-    multipart_t tmp (message_t ("Fifty", 5));
-    assert (tmp.size () == 1);
+    multipart_t tmp(message_t("Fifty", 5));
+    assert(tmp.size() == 1);
 
-    multipart_t mid = multipart_t::create (49.0f);
-    mid.append (std::move (tmp));
-    assert (mid.size () == 2);
-    assert (tmp.empty ());
+    multipart_t mid = multipart_t::create(49.0f);
+    mid.append(std::move(tmp));
+    assert(mid.size() == 2);
+    assert(tmp.empty());
 
-    multipart_t merged (std::move (mid));
-    merged.prepend (std::move (head));
-    merged.append (std::move (tail));
-    assert (merged.size () == 6);
-    assert (head.empty ());
-    assert (tail.empty ());
+    multipart_t merged(std::move(mid));
+    merged.prepend(std::move(head));
+    merged.append(std::move(tail));
+    assert(merged.size() == 6);
+    assert(head.empty());
+    assert(tail.empty());
 
-    ok = merged.send (output);
-    assert (merged.empty ());
-    assert (ok);
+    ok = merged.send(output);
+    assert(merged.empty());
+    assert(ok);
 
-    multipart_t received (input);
-    assert (received.size () == 6);
+    multipart_t received(input);
+    assert(received.size() == 6);
 
-    str = received.popstr ();
-    assert (received.size () == 5);
-    assert (str == "One");
+    str = received.popstr();
+    assert(received.size() == 5);
+    assert(str == "One");
 
-    str = received.popstr ();
-    assert (received.size () == 4);
-    assert (str == "Two");
+    str = received.popstr();
+    assert(received.size() == 4);
+    assert(str == "Two");
 
-    num = received.poptyp<float> ();
-    assert (received.size () == 3);
-    assert (num == 49.0f);
+    num = received.poptyp<float>();
+    assert(received.size() == 3);
+    assert(num == 49.0f);
 
-    str = received.popstr ();
-    assert (received.size () == 2);
-    assert (str == "Fifty");
+    str = received.popstr();
+    assert(received.size() == 2);
+    assert(str == "Fifty");
 
-    str = received.popstr ();
-    assert (received.size () == 1);
-    assert (str == "Ninety-nine");
+    str = received.popstr();
+    assert(received.size() == 1);
+    assert(str == "Ninety-nine");
 
-    str = received.popstr ();
-    assert (received.empty ());
-    assert (str == "One-hundred");
+    str = received.popstr();
+    assert(received.empty());
+    assert(str == "One-hundred");
 }
 #endif

--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -5,68 +5,68 @@
 #include <array>
 #include <memory>
 
-TEST (poller, create_destroy)
+TEST(poller, create_destroy)
 {
     zmq::poller_t<> poller;
 }
 
-static_assert (!std::is_copy_constructible<zmq::poller_t<>>::value,
-               "poller_t should not be copy-constructible");
-static_assert (!std::is_copy_assignable<zmq::poller_t<>>::value,
-               "poller_t should not be copy-assignable");
+static_assert(!std::is_copy_constructible<zmq::poller_t<>>::value,
+              "poller_t should not be copy-constructible");
+static_assert(!std::is_copy_assignable<zmq::poller_t<>>::value,
+              "poller_t should not be copy-assignable");
 
-TEST (poller, move_construct_empty)
+TEST(poller, move_construct_empty)
 {
     zmq::poller_t<> a;
-    zmq::poller_t<> b = std::move (a);
+    zmq::poller_t<> b = std::move(a);
 }
 
-TEST (poller, move_assign_empty)
+TEST(poller, move_assign_empty)
 {
     zmq::poller_t<> a;
     zmq::poller_t<> b;
-    b = std::move (a);
+    b = std::move(a);
 }
 
-TEST (poller, move_construct_non_empty)
+TEST(poller, move_construct_non_empty)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
 
     zmq::poller_t<> a;
-    a.add (socket, ZMQ_POLLIN, nullptr);
-    zmq::poller_t<> b = std::move (a);
+    a.add(socket, ZMQ_POLLIN, nullptr);
+    zmq::poller_t<> b = std::move(a);
 }
 
-TEST (poller, move_assign_non_empty)
+TEST(poller, move_assign_non_empty)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
 
     zmq::poller_t<> a;
-    a.add (socket, ZMQ_POLLIN, nullptr);
+    a.add(socket, ZMQ_POLLIN, nullptr);
     zmq::poller_t<> b;
-    b = std::move (a);
+    b = std::move(a);
 }
 
-TEST (poller, add_nullptr)
+TEST(poller, add_nullptr)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::poller_t<> poller;
-    ASSERT_NO_THROW (poller.add (socket, ZMQ_POLLIN, nullptr));
+    ASSERT_NO_THROW(poller.add(socket, ZMQ_POLLIN, nullptr));
 }
 
-TEST (poller, add_non_nullptr)
+TEST(poller, add_non_nullptr)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::poller_t<> poller;
     int i;
-    ASSERT_NO_THROW (poller.add (socket, ZMQ_POLLIN, &i));
+    ASSERT_NO_THROW(poller.add(socket, ZMQ_POLLIN, &i));
 }
 
-TEST (poller, add_handler_invalid_events_type)
+TEST(poller, add_handler_invalid_events_type)
 {
     /// \todo is it good that this is accepted? should probably already be
     ///   checked by zmq_poller_add/modify in libzmq:
@@ -75,226 +75,222 @@ TEST (poller, add_handler_invalid_events_type)
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::poller_t<> poller;
     short invalid_events_type = 2 << 10;
-    ASSERT_NO_THROW (poller.add (socket, invalid_events_type, nullptr));
+    ASSERT_NO_THROW(poller.add(socket, invalid_events_type, nullptr));
 }
 
-TEST (poller, add_handler_twice_throws)
+TEST(poller, add_handler_twice_throws)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::poller_t<> poller;
-    poller.add (socket, ZMQ_POLLIN, nullptr);
+    poller.add(socket, ZMQ_POLLIN, nullptr);
     /// \todo the actual error code should be checked
-    ASSERT_THROW (poller.add (socket, ZMQ_POLLIN, nullptr), zmq::error_t);
+    ASSERT_THROW(poller.add(socket, ZMQ_POLLIN, nullptr), zmq::error_t);
 }
 
-TEST (poller, wait_with_no_handlers_throws)
+TEST(poller, wait_with_no_handlers_throws)
 {
     zmq::poller_t<> poller;
     std::vector<zmq_poller_event_t> events;
     /// \todo the actual error code should be checked
-    ASSERT_THROW (poller.wait_all (events, std::chrono::milliseconds{10}),
-                  zmq::error_t);
+    ASSERT_THROW(poller.wait_all(events, std::chrono::milliseconds{10}),
+                 zmq::error_t);
 }
 
-TEST (poller, remove_unregistered_throws)
+TEST(poller, remove_unregistered_throws)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::poller_t<> poller;
     /// \todo the actual error code should be checked
-    ASSERT_THROW (poller.remove (socket), zmq::error_t);
+    ASSERT_THROW(poller.remove(socket), zmq::error_t);
 }
 
-TEST (poller, remove_registered_empty)
+TEST(poller, remove_registered_empty)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::poller_t<> poller;
-    poller.add (socket, ZMQ_POLLIN, nullptr);
-    ASSERT_NO_THROW (poller.remove (socket));
+    poller.add(socket, ZMQ_POLLIN, nullptr);
+    ASSERT_NO_THROW(poller.remove(socket));
 }
 
-TEST (poller, remove_registered_non_empty)
+TEST(poller, remove_registered_non_empty)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::poller_t<> poller;
-    poller.add (socket, ZMQ_POLLIN, nullptr);
-    ASSERT_NO_THROW (poller.remove (socket));
+    poller.add(socket, ZMQ_POLLIN, nullptr);
+    ASSERT_NO_THROW(poller.remove(socket));
 }
 
-TEST (poller, poll_basic)
+TEST(poller, poll_basic)
 {
     common_server_client_setup s;
 
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
 
     zmq::poller_t<int> poller;
     std::vector<zmq_poller_event_t> events{1};
     int i = 0;
-    ASSERT_NO_THROW (poller.add (s.server, ZMQ_POLLIN, &i));
-    ASSERT_EQ (1, poller.wait_all (events, std::chrono::milliseconds{-1}));
-    ASSERT_EQ (s.server, events[0].socket);
-    ASSERT_EQ (&i, events[0].user_data);
+    ASSERT_NO_THROW(poller.add(s.server, ZMQ_POLLIN, &i));
+    ASSERT_EQ(1, poller.wait_all(events, std::chrono::milliseconds{-1}));
+    ASSERT_EQ(s.server, events[0].socket);
+    ASSERT_EQ(&i, events[0].user_data);
 }
 
-TEST (poller, add_invalid_socket_throws)
+TEST(poller, add_invalid_socket_throws)
 {
     zmq::context_t context;
     zmq::poller_t<> poller;
     zmq::socket_t a{context, zmq::socket_type::router};
-    zmq::socket_t b{std::move (a)};
-    ASSERT_THROW (poller.add (a, ZMQ_POLLIN, nullptr), zmq::error_t);
+    zmq::socket_t b{std::move(a)};
+    ASSERT_THROW(poller.add(a, ZMQ_POLLIN, nullptr), zmq::error_t);
 }
 
-TEST (poller, remove_invalid_socket_throws)
+TEST(poller, remove_invalid_socket_throws)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::poller_t<> poller;
-    ASSERT_NO_THROW (poller.add (socket, ZMQ_POLLIN, nullptr));
+    ASSERT_NO_THROW(poller.add(socket, ZMQ_POLLIN, nullptr));
     std::vector<zmq::socket_t> sockets;
-    sockets.emplace_back (std::move (socket));
-    ASSERT_THROW (poller.remove (socket), zmq::error_t);
-    ASSERT_NO_THROW (poller.remove (sockets[0]));
+    sockets.emplace_back(std::move(socket));
+    ASSERT_THROW(poller.remove(socket), zmq::error_t);
+    ASSERT_NO_THROW(poller.remove(sockets[0]));
 }
 
-TEST (poller, modify_empty_throws)
+TEST(poller, modify_empty_throws)
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::push};
     zmq::poller_t<> poller;
-    ASSERT_THROW (poller.modify (socket, ZMQ_POLLIN), zmq::error_t);
+    ASSERT_THROW(poller.modify(socket, ZMQ_POLLIN), zmq::error_t);
 }
 
-TEST (poller, modify_invalid_socket_throws)
+TEST(poller, modify_invalid_socket_throws)
 {
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
-    zmq::socket_t b{std::move (a)};
+    zmq::socket_t b{std::move(a)};
     zmq::poller_t<> poller;
-    ASSERT_THROW (poller.modify (a, ZMQ_POLLIN), zmq::error_t);
+    ASSERT_THROW(poller.modify(a, ZMQ_POLLIN), zmq::error_t);
 }
 
-TEST (poller, modify_not_added_throws)
+TEST(poller, modify_not_added_throws)
 {
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::socket_t b{context, zmq::socket_type::push};
     zmq::poller_t<> poller;
-    ASSERT_NO_THROW (poller.add (a, ZMQ_POLLIN, nullptr));
-    ASSERT_THROW (poller.modify (b, ZMQ_POLLIN), zmq::error_t);
+    ASSERT_NO_THROW(poller.add(a, ZMQ_POLLIN, nullptr));
+    ASSERT_THROW(poller.modify(b, ZMQ_POLLIN), zmq::error_t);
 }
 
-TEST (poller, modify_simple)
+TEST(poller, modify_simple)
 {
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::poller_t<> poller;
-    ASSERT_NO_THROW (poller.add (a, ZMQ_POLLIN, nullptr));
-    ASSERT_NO_THROW (poller.modify (a, ZMQ_POLLIN | ZMQ_POLLOUT));
+    ASSERT_NO_THROW(poller.add(a, ZMQ_POLLIN, nullptr));
+    ASSERT_NO_THROW(poller.modify(a, ZMQ_POLLIN | ZMQ_POLLOUT));
 }
 
-TEST (poller, poll_client_server)
+TEST(poller, poll_client_server)
 {
     // Setup server and client
     common_server_client_setup s;
 
     // Setup poller
     zmq::poller_t<> poller;
-    ASSERT_NO_THROW (poller.add (s.server, ZMQ_POLLIN, s.server));
+    ASSERT_NO_THROW(poller.add(s.server, ZMQ_POLLIN, s.server));
 
     // client sends message
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
 
     // wait for message and verify events
-    std::vector<zmq_poller_event_t> events (1);
-    ASSERT_EQ (1, poller.wait_all (events, std::chrono::milliseconds{500}));
-    ASSERT_EQ (ZMQ_POLLIN, events[0].events);
+    std::vector<zmq_poller_event_t> events(1);
+    ASSERT_EQ(1, poller.wait_all(events, std::chrono::milliseconds{500}));
+    ASSERT_EQ(ZMQ_POLLIN, events[0].events);
 
     // Modify server socket with pollout flag
-    ASSERT_NO_THROW (poller.modify (s.server, ZMQ_POLLIN | ZMQ_POLLOUT));
-    ASSERT_EQ (1, poller.wait_all (events, std::chrono::milliseconds{500}));
-    ASSERT_EQ (ZMQ_POLLIN | ZMQ_POLLOUT, events[0].events);
+    ASSERT_NO_THROW(poller.modify(s.server, ZMQ_POLLIN | ZMQ_POLLOUT));
+    ASSERT_EQ(1, poller.wait_all(events, std::chrono::milliseconds{500}));
+    ASSERT_EQ(ZMQ_POLLIN | ZMQ_POLLOUT, events[0].events);
 }
 
-TEST (poller, wait_one_return)
+TEST(poller, wait_one_return)
 {
     // Setup server and client
     common_server_client_setup s;
 
     // Setup poller
     zmq::poller_t<> poller;
-    ASSERT_NO_THROW (poller.add (s.server, ZMQ_POLLIN, nullptr));
+    ASSERT_NO_THROW(poller.add(s.server, ZMQ_POLLIN, nullptr));
 
     // client sends message
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
 
     // wait for message and verify events
-    std::vector<zmq_poller_event_t> events (1);
-    ASSERT_EQ (1, poller.wait_all (events, std::chrono::milliseconds{500}));
+    std::vector<zmq_poller_event_t> events(1);
+    ASSERT_EQ(1, poller.wait_all(events, std::chrono::milliseconds{500}));
 }
 
-TEST (poller, wait_on_move_constructed_poller)
+TEST(poller, wait_on_move_constructed_poller)
 {
     common_server_client_setup s;
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
     zmq::poller_t<> a;
-    ASSERT_NO_THROW (a.add (s.server, ZMQ_POLLIN, nullptr));
-    zmq::poller_t<> b{std::move (a)};
-    std::vector<zmq_poller_event_t> events (1);
+    ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, nullptr));
+    zmq::poller_t<> b{std::move(a)};
+    std::vector<zmq_poller_event_t> events(1);
     /// \todo the actual error code should be checked
-    ASSERT_THROW (a.wait_all (events, std::chrono::milliseconds{10}),
-                  zmq::error_t);
-    ASSERT_EQ (1, b.wait_all (events, std::chrono::milliseconds{-1}));
+    ASSERT_THROW(a.wait_all(events, std::chrono::milliseconds{10}), zmq::error_t);
+    ASSERT_EQ(1, b.wait_all(events, std::chrono::milliseconds{-1}));
 }
 
-TEST (poller, wait_on_move_assigned_poller)
+TEST(poller, wait_on_move_assigned_poller)
 {
     common_server_client_setup s;
-    ASSERT_NO_THROW (s.client.send ("Hi"));
+    ASSERT_NO_THROW(s.client.send("Hi"));
     zmq::poller_t<> a;
-    ASSERT_NO_THROW (a.add (s.server, ZMQ_POLLIN, nullptr));
+    ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, nullptr));
     zmq::poller_t<> b;
-    b = {std::move (a)};
+    b = {std::move(a)};
     /// \todo the actual error code should be checked
-    std::vector<zmq_poller_event_t> events (1);
-    ASSERT_THROW (a.wait_all (events, std::chrono::milliseconds{10}),
-                  zmq::error_t);
-    ASSERT_EQ (1, b.wait_all (events, std::chrono::milliseconds{-1}));
+    std::vector<zmq_poller_event_t> events(1);
+    ASSERT_THROW(a.wait_all(events, std::chrono::milliseconds{10}), zmq::error_t);
+    ASSERT_EQ(1, b.wait_all(events, std::chrono::milliseconds{-1}));
 }
 
-TEST (poller, remove_from_handler)
+TEST(poller, remove_from_handler)
 {
     constexpr auto ITER_NO = 10;
 
     // Setup servers and clients
     std::vector<common_server_client_setup> setup_list;
     for (auto i = 0; i < ITER_NO; ++i)
-        setup_list.emplace_back (common_server_client_setup{});
+        setup_list.emplace_back(common_server_client_setup{});
 
     // Setup poller
     zmq::poller_t<> poller;
     for (auto i = 0; i < ITER_NO; ++i) {
-        ASSERT_NO_THROW (
-          poller.add (setup_list[i].server, ZMQ_POLLIN, nullptr));
+        ASSERT_NO_THROW(poller.add(setup_list[i].server, ZMQ_POLLIN, nullptr));
     }
     // Clients send messages
     for (auto &s : setup_list) {
-        ASSERT_NO_THROW (s.client.send ("Hi"));
+        ASSERT_NO_THROW(s.client.send("Hi"));
     }
 
     // Wait for all servers to receive a message
     for (auto &s : setup_list) {
         zmq::pollitem_t items[] = {{s.server, 0, ZMQ_POLLIN, 0}};
-        zmq::poll (&items[0], 1);
+        zmq::poll(&items[0], 1);
     }
 
     // Fire all handlers in one wait
-    std::vector<zmq_poller_event_t> events (ITER_NO);
-    ASSERT_EQ (ITER_NO,
-               poller.wait_all (events, std::chrono::milliseconds{-1}));
+    std::vector<zmq_poller_event_t> events(ITER_NO);
+    ASSERT_EQ(ITER_NO, poller.wait_all(events, std::chrono::milliseconds{-1}));
 }
 
 #endif

--- a/tests/socket.cpp
+++ b/tests/socket.cpp
@@ -1,16 +1,16 @@
 #include <gtest/gtest.h>
 #include <zmq.hpp>
 
-TEST (socket, create_destroy)
+TEST(socket, create_destroy)
 {
     zmq::context_t context;
-    zmq::socket_t socket (context, ZMQ_ROUTER);
+    zmq::socket_t socket(context, ZMQ_ROUTER);
 }
 
 #ifdef ZMQ_CPP11
-TEST (socket, create_by_enum_destroy)
+TEST(socket, create_by_enum_destroy)
 {
     zmq::context_t context;
-    zmq::socket_t socket (context, zmq::socket_type::router);
+    zmq::socket_t socket(context, zmq::socket_type::router);
 }
 #endif

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -8,10 +8,11 @@
 
 class loopback_ip4_binder
 {
-public:
+  public:
     loopback_ip4_binder(zmq::socket_t &socket) { bind(socket); }
     std::string endpoint() { return endpoint_; }
-private:
+
+  private:
     // Helper function used in constructor
     // as Gtest allows ASSERT_* only in void returning functions
     // and constructor/destructor are not.
@@ -20,8 +21,8 @@ private:
         ASSERT_NO_THROW(socket.bind("tcp://127.0.0.1:*"));
         std::array<char, 100> endpoint{};
         size_t endpoint_size = endpoint.size();
-        ASSERT_NO_THROW(socket.getsockopt(ZMQ_LAST_ENDPOINT, endpoint.data(),
-                                          &endpoint_size));
+        ASSERT_NO_THROW(
+          socket.getsockopt(ZMQ_LAST_ENDPOINT, endpoint.data(), &endpoint_size));
         ASSERT_TRUE(endpoint_size < endpoint.size());
         endpoint_ = std::string{endpoint.data()};
     }
@@ -30,20 +31,17 @@ private:
 
 struct common_server_client_setup
 {
-    common_server_client_setup ()
-    {
-        init ();
-    }
+    common_server_client_setup() { init(); }
 
     void init()
     {
-        endpoint = loopback_ip4_binder {server}.endpoint ();
-        ASSERT_NO_THROW (client.connect (endpoint));
+        endpoint = loopback_ip4_binder{server}.endpoint();
+        ASSERT_NO_THROW(client.connect(endpoint));
     }
 
     zmq::context_t context;
-    zmq::socket_t server {context, zmq::socket_type::server};
-    zmq::socket_t client {context, zmq::socket_type::client};
+    zmq::socket_t server{context, zmq::socket_type::server};
+    zmq::socket_t client{context, zmq::socket_type::client};
     std::string endpoint;
 };
 #endif

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -27,11 +27,11 @@
 #define __ZMQ_HPP_INCLUDED__
 
 #if (__cplusplus >= 201402L)
-#define ZMQ_DEPRECATED(msg) [[deprecated (msg)]]
+#define ZMQ_DEPRECATED(msg) [[deprecated(msg)]]
 #elif defined(_MSC_VER)
-#define ZMQ_DEPRECATED(msg) __declspec(deprecated (msg))
+#define ZMQ_DEPRECATED(msg) __declspec(deprecated(msg))
 #elif defined(__GNUC__)
-#define ZMQ_DEPRECATED(msg) __attribute__ ((deprecated (msg)))
+#define ZMQ_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #endif
 
 #if (__cplusplus >= 201103L)
@@ -66,9 +66,9 @@
 #define CPPZMQ_VERSION_MINOR 3
 #define CPPZMQ_VERSION_PATCH 0
 
-#define CPPZMQ_VERSION                                                         \
-    ZMQ_MAKE_VERSION (CPPZMQ_VERSION_MAJOR, CPPZMQ_VERSION_MINOR,              \
-                      CPPZMQ_VERSION_PATCH)
+#define CPPZMQ_VERSION                                                              \
+    ZMQ_MAKE_VERSION(CPPZMQ_VERSION_MAJOR, CPPZMQ_VERSION_MINOR,                    \
+                     CPPZMQ_VERSION_PATCH)
 
 #ifdef ZMQ_CPP11
 #include <chrono>
@@ -79,8 +79,7 @@
 #endif
 
 //  Detect whether the compiler supports C++11 rvalue references.
-#if (defined(__GNUC__)                                                         \
-     && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 2))                \
+#if (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 2))   \
      && defined(__GXX_EXPERIMENTAL_CXX0X__))
 #define ZMQ_HAS_RVALUE_REFS
 #define ZMQ_DELETED_FUNCTION = delete
@@ -120,14 +119,14 @@ typedef struct
 
 // Avoid using deprecated message receive function when possible
 #if ZMQ_VERSION < ZMQ_MAKE_VERSION(3, 2, 0)
-#define zmq_msg_recv(msg, socket, flags) zmq_recvmsg (socket, msg, flags)
+#define zmq_msg_recv(msg, socket, flags) zmq_recvmsg(socket, msg, flags)
 #endif
 
 
 // In order to prevent unused variable warnings when building in non-debug
 // mode use this macro to make assertions.
 #ifndef NDEBUG
-#define ZMQ_ASSERT(expression) assert (expression)
+#define ZMQ_ASSERT(expression) assert(expression)
 #else
 #define ZMQ_ASSERT(expression) (void) (expression)
 #endif
@@ -140,77 +139,74 @@ typedef zmq_pollitem_t pollitem_t;
 class error_t : public std::exception
 {
   public:
-    error_t () : errnum (zmq_errno ()) {}
+    error_t() : errnum(zmq_errno()) {}
 #ifdef ZMQ_CPP11
-    virtual const char *what () const noexcept { return zmq_strerror (errnum); }
+    virtual const char *what() const noexcept { return zmq_strerror(errnum); }
 #else
-    virtual const char *what () const throw () { return zmq_strerror (errnum); }
+    virtual const char *what() const throw() { return zmq_strerror(errnum); }
 #endif
-    int num () const { return errnum; }
+    int num() const { return errnum; }
 
   private:
     int errnum;
 };
 
-inline int
-poll (zmq_pollitem_t const *items_, size_t nitems_, long timeout_ = -1)
+inline int poll(zmq_pollitem_t const *items_, size_t nitems_, long timeout_ = -1)
 {
-    int rc = zmq_poll (const_cast<zmq_pollitem_t *> (items_),
-                       static_cast<int> (nitems_), timeout_);
+    int rc = zmq_poll(const_cast<zmq_pollitem_t *>(items_),
+                      static_cast<int>(nitems_), timeout_);
     if (rc < 0)
-        throw error_t ();
+        throw error_t();
     return rc;
 }
 
 #ifdef ZMQ_CPP11
-inline int poll (zmq_pollitem_t const *items,
-                 size_t nitems,
-                 std::chrono::milliseconds timeout)
+inline int
+poll(zmq_pollitem_t const *items, size_t nitems, std::chrono::milliseconds timeout)
 {
-    return poll (items, nitems, static_cast<long> (timeout.count ()));
+    return poll(items, nitems, static_cast<long>(timeout.count()));
 }
 
-inline int poll (std::vector<zmq_pollitem_t> const &items,
-                 std::chrono::milliseconds timeout)
+inline int poll(std::vector<zmq_pollitem_t> const &items,
+                std::chrono::milliseconds timeout)
 {
-    return poll (items.data (), items.size (),
-                 static_cast<long> (timeout.count ()));
+    return poll(items.data(), items.size(), static_cast<long>(timeout.count()));
 }
 
-inline int poll (std::vector<zmq_pollitem_t> const &items, long timeout_ = -1)
+inline int poll(std::vector<zmq_pollitem_t> const &items, long timeout_ = -1)
 {
-    return poll (items.data (), items.size (), timeout_);
+    return poll(items.data(), items.size(), timeout_);
 }
 #endif
 
 
-inline void proxy (void *frontend, void *backend, void *capture)
+inline void proxy(void *frontend, void *backend, void *capture)
 {
-    int rc = zmq_proxy (frontend, backend, capture);
+    int rc = zmq_proxy(frontend, backend, capture);
     if (rc != 0)
-        throw error_t ();
+        throw error_t();
 }
 
 #ifdef ZMQ_HAS_PROXY_STEERABLE
 inline void
-proxy_steerable (void *frontend, void *backend, void *capture, void *control)
+proxy_steerable(void *frontend, void *backend, void *capture, void *control)
 {
-    int rc = zmq_proxy_steerable (frontend, backend, capture, control);
+    int rc = zmq_proxy_steerable(frontend, backend, capture, control);
     if (rc != 0)
-        throw error_t ();
+        throw error_t();
 }
 #endif
 
-inline void version (int *major_, int *minor_, int *patch_)
+inline void version(int *major_, int *minor_, int *patch_)
 {
-    zmq_version (major_, minor_, patch_);
+    zmq_version(major_, minor_, patch_);
 }
 
 #ifdef ZMQ_CPP11
-inline std::tuple<int, int, int> version ()
+inline std::tuple<int, int, int> version()
 {
     std::tuple<int, int, int> v;
-    zmq_version (&std::get<0> (v), &std::get<1> (v), &std::get<2> (v));
+    zmq_version(&std::get<0>(v), &std::get<1>(v), &std::get<2>(v));
     return v;
 }
 #endif
@@ -220,30 +216,30 @@ class message_t
     friend class socket_t;
 
   public:
-    inline message_t ()
+    inline message_t()
     {
-        int rc = zmq_msg_init (&msg);
+        int rc = zmq_msg_init(&msg);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline explicit message_t (size_t size_)
+    inline explicit message_t(size_t size_)
     {
-        int rc = zmq_msg_init_size (&msg, size_);
+        int rc = zmq_msg_init_size(&msg, size_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    template <typename I> message_t (I first, I last) : msg ()
+    template<typename I> message_t(I first, I last) : msg()
     {
         typedef typename std::iterator_traits<I>::difference_type size_type;
         typedef typename std::iterator_traits<I>::value_type value_t;
 
-        size_type const size_ = std::distance (first, last) * sizeof (value_t);
-        int const rc = zmq_msg_init_size (&msg, size_);
+        size_type const size_ = std::distance(first, last) * sizeof(value_t);
+        int const rc = zmq_msg_init_size(&msg, size_);
         if (rc != 0)
-            throw error_t ();
-        value_t *dest = data<value_t> ();
+            throw error_t();
+        value_t *dest = data<value_t>();
         while (first != last) {
             *dest = *first;
             ++dest;
@@ -251,178 +247,170 @@ class message_t
         }
     }
 
-    inline message_t (const void *data_, size_t size_)
+    inline message_t(const void *data_, size_t size_)
     {
-        int rc = zmq_msg_init_size (&msg, size_);
+        int rc = zmq_msg_init_size(&msg, size_);
         if (rc != 0)
-            throw error_t ();
-        memcpy (data (), data_, size_);
+            throw error_t();
+        memcpy(data(), data_, size_);
     }
 
-    inline message_t (void *data_,
-                      size_t size_,
-                      free_fn *ffn_,
-                      void *hint_ = NULL)
+    inline message_t(void *data_, size_t size_, free_fn *ffn_, void *hint_ = NULL)
     {
-        int rc = zmq_msg_init_data (&msg, data_, size_, ffn_, hint_);
+        int rc = zmq_msg_init_data(&msg, data_, size_, ffn_, hint_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
 #if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)
-    template <typename T>
-    message_t (const T &msg_) : message_t (std::begin (msg_), std::end (msg_))
+    template<typename T>
+    message_t(const T &msg_) : message_t(std::begin(msg_), std::end(msg_))
     {
     }
 #endif
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    inline message_t (message_t &&rhs) : msg (rhs.msg)
+    inline message_t(message_t &&rhs) : msg(rhs.msg)
     {
-        int rc = zmq_msg_init (&rhs.msg);
+        int rc = zmq_msg_init(&rhs.msg);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline message_t &operator= (message_t &&rhs) ZMQ_NOTHROW
+    inline message_t &operator=(message_t &&rhs) ZMQ_NOTHROW
     {
-        std::swap (msg, rhs.msg);
+        std::swap(msg, rhs.msg);
         return *this;
     }
 #endif
 
-    inline ~message_t () ZMQ_NOTHROW
+    inline ~message_t() ZMQ_NOTHROW
     {
-        int rc = zmq_msg_close (&msg);
-        ZMQ_ASSERT (rc == 0);
+        int rc = zmq_msg_close(&msg);
+        ZMQ_ASSERT(rc == 0);
     }
 
-    inline void rebuild ()
+    inline void rebuild()
     {
-        int rc = zmq_msg_close (&msg);
+        int rc = zmq_msg_close(&msg);
         if (rc != 0)
-            throw error_t ();
-        rc = zmq_msg_init (&msg);
+            throw error_t();
+        rc = zmq_msg_init(&msg);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline void rebuild (size_t size_)
+    inline void rebuild(size_t size_)
     {
-        int rc = zmq_msg_close (&msg);
+        int rc = zmq_msg_close(&msg);
         if (rc != 0)
-            throw error_t ();
-        rc = zmq_msg_init_size (&msg, size_);
+            throw error_t();
+        rc = zmq_msg_init_size(&msg, size_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline void rebuild (const void *data_, size_t size_)
+    inline void rebuild(const void *data_, size_t size_)
     {
-        int rc = zmq_msg_close (&msg);
+        int rc = zmq_msg_close(&msg);
         if (rc != 0)
-            throw error_t ();
-        rc = zmq_msg_init_size (&msg, size_);
+            throw error_t();
+        rc = zmq_msg_init_size(&msg, size_);
         if (rc != 0)
-            throw error_t ();
-        memcpy (data (), data_, size_);
+            throw error_t();
+        memcpy(data(), data_, size_);
     }
 
-    inline void
-    rebuild (void *data_, size_t size_, free_fn *ffn_, void *hint_ = NULL)
+    inline void rebuild(void *data_, size_t size_, free_fn *ffn_, void *hint_ = NULL)
     {
-        int rc = zmq_msg_close (&msg);
+        int rc = zmq_msg_close(&msg);
         if (rc != 0)
-            throw error_t ();
-        rc = zmq_msg_init_data (&msg, data_, size_, ffn_, hint_);
+            throw error_t();
+        rc = zmq_msg_init_data(&msg, data_, size_, ffn_, hint_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline void move (message_t const *msg_)
+    inline void move(message_t const *msg_)
     {
-        int rc = zmq_msg_move (&msg, const_cast<zmq_msg_t *> (&(msg_->msg)));
+        int rc = zmq_msg_move(&msg, const_cast<zmq_msg_t *>(&(msg_->msg)));
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline void copy (message_t const *msg_)
+    inline void copy(message_t const *msg_)
     {
-        int rc = zmq_msg_copy (&msg, const_cast<zmq_msg_t *> (&(msg_->msg)));
+        int rc = zmq_msg_copy(&msg, const_cast<zmq_msg_t *>(&(msg_->msg)));
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline bool more () const ZMQ_NOTHROW
+    inline bool more() const ZMQ_NOTHROW
     {
-        int rc = zmq_msg_more (const_cast<zmq_msg_t *> (&msg));
+        int rc = zmq_msg_more(const_cast<zmq_msg_t *>(&msg));
         return rc != 0;
     }
 
-    inline void *data () ZMQ_NOTHROW { return zmq_msg_data (&msg); }
+    inline void *data() ZMQ_NOTHROW { return zmq_msg_data(&msg); }
 
-    inline const void *data () const ZMQ_NOTHROW
+    inline const void *data() const ZMQ_NOTHROW
     {
-        return zmq_msg_data (const_cast<zmq_msg_t *> (&msg));
+        return zmq_msg_data(const_cast<zmq_msg_t *>(&msg));
     }
 
-    inline size_t size () const ZMQ_NOTHROW
+    inline size_t size() const ZMQ_NOTHROW
     {
-        return zmq_msg_size (const_cast<zmq_msg_t *> (&msg));
+        return zmq_msg_size(const_cast<zmq_msg_t *>(&msg));
     }
 
-    template <typename T> T *data () ZMQ_NOTHROW
+    template<typename T> T *data() ZMQ_NOTHROW { return static_cast<T *>(data()); }
+
+    template<typename T> T const *data() const ZMQ_NOTHROW
     {
-        return static_cast<T *> (data ());
+        return static_cast<T const *>(data());
     }
 
-    template <typename T> T const *data () const ZMQ_NOTHROW
-    {
-        return static_cast<T const *> (data ());
-    }
-
-    ZMQ_DEPRECATED ("from 4.3.0, use operator== instead")
-    inline bool equal (const message_t *other) const ZMQ_NOTHROW
+    ZMQ_DEPRECATED("from 4.3.0, use operator== instead")
+    inline bool equal(const message_t *other) const ZMQ_NOTHROW
     {
         return *this == *other;
     }
 
-    inline bool operator== (const message_t &other) const ZMQ_NOTHROW
+    inline bool operator==(const message_t &other) const ZMQ_NOTHROW
     {
-        const size_t my_size = size ();
-        return my_size == other.size ()
-               && 0 == memcmp (data (), other.data (), my_size);
+        const size_t my_size = size();
+        return my_size == other.size() && 0 == memcmp(data(), other.data(), my_size);
     }
 
-    inline bool operator!= (const message_t &other) const ZMQ_NOTHROW
+    inline bool operator!=(const message_t &other) const ZMQ_NOTHROW
     {
         return !(*this == other);
     }
 
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 1, 0)
-    inline const char *gets (const char *property_)
+    inline const char *gets(const char *property_)
     {
-        const char *value = zmq_msg_gets (&msg, property_);
+        const char *value = zmq_msg_gets(&msg, property_);
         if (value == NULL)
-            throw error_t ();
+            throw error_t();
         return value;
     }
 #endif
     /** Dump content to string. Ascii chars are readable, the rest is printed as hex.
          *  Probably ridiculously slow.
          */
-    inline std::string str () const
+    inline std::string str() const
     {
         // Partly mutuated from the same method in zmq::multipart_t
         std::stringstream os;
 
-        const unsigned char *msg_data = this->data<unsigned char> ();
+        const unsigned char *msg_data = this->data<unsigned char>();
         unsigned char byte;
-        size_t size = this->size ();
+        size_t size = this->size();
         int is_ascii[2] = {0, 0};
 
-        os << "zmq::message_t [size " << std::dec << std::setw (3)
-           << std::setfill ('0') << size << "] (";
+        os << "zmq::message_t [size " << std::dec << std::setw(3)
+           << std::setfill('0') << size << "] (";
         // Totally arbitrary
         if (size >= 1000) {
             os << "... too big to print)";
@@ -437,14 +425,14 @@ class message_t
                 if (is_ascii[1]) {
                     os << byte;
                 } else {
-                    os << std::hex << std::uppercase << std::setw (2)
-                       << std::setfill ('0') << static_cast<short> (byte);
+                    os << std::hex << std::uppercase << std::setw(2)
+                       << std::setfill('0') << static_cast<short>(byte);
                 }
                 is_ascii[0] = is_ascii[1];
             }
             os << ")";
         }
-        return os.str ();
+        return os.str();
     }
 
   private:
@@ -453,8 +441,8 @@ class message_t
 
     //  Disable implicit message copying, so that users won't use shared
     //  messages (less efficient) without being aware of the fact.
-    message_t (const message_t &) ZMQ_DELETED_FUNCTION;
-    void operator= (const message_t &) ZMQ_DELETED_FUNCTION;
+    message_t(const message_t &) ZMQ_DELETED_FUNCTION;
+    void operator=(const message_t &) ZMQ_DELETED_FUNCTION;
 };
 
 class context_t
@@ -462,78 +450,72 @@ class context_t
     friend class socket_t;
 
   public:
-    inline context_t ()
+    inline context_t()
     {
-        ptr = zmq_ctx_new ();
+        ptr = zmq_ctx_new();
         if (ptr == NULL)
-            throw error_t ();
+            throw error_t();
     }
 
 
-    inline explicit context_t (int io_threads_,
-                               int max_sockets_ = ZMQ_MAX_SOCKETS_DFLT)
+    inline explicit context_t(int io_threads_,
+                              int max_sockets_ = ZMQ_MAX_SOCKETS_DFLT)
     {
-        ptr = zmq_ctx_new ();
+        ptr = zmq_ctx_new();
         if (ptr == NULL)
-            throw error_t ();
+            throw error_t();
 
-        int rc = zmq_ctx_set (ptr, ZMQ_IO_THREADS, io_threads_);
-        ZMQ_ASSERT (rc == 0);
+        int rc = zmq_ctx_set(ptr, ZMQ_IO_THREADS, io_threads_);
+        ZMQ_ASSERT(rc == 0);
 
-        rc = zmq_ctx_set (ptr, ZMQ_MAX_SOCKETS, max_sockets_);
-        ZMQ_ASSERT (rc == 0);
+        rc = zmq_ctx_set(ptr, ZMQ_MAX_SOCKETS, max_sockets_);
+        ZMQ_ASSERT(rc == 0);
     }
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    inline context_t (context_t &&rhs) ZMQ_NOTHROW : ptr (rhs.ptr)
+    inline context_t(context_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr) { rhs.ptr = NULL; }
+    inline context_t &operator=(context_t &&rhs) ZMQ_NOTHROW
     {
-        rhs.ptr = NULL;
-    }
-    inline context_t &operator= (context_t &&rhs) ZMQ_NOTHROW
-    {
-        std::swap (ptr, rhs.ptr);
+        std::swap(ptr, rhs.ptr);
         return *this;
     }
 #endif
 
-    inline int setctxopt (int option_, int optval_)
+    inline int setctxopt(int option_, int optval_)
     {
-        int rc = zmq_ctx_set (ptr, option_, optval_);
-        ZMQ_ASSERT (rc == 0);
+        int rc = zmq_ctx_set(ptr, option_, optval_);
+        ZMQ_ASSERT(rc == 0);
         return rc;
     }
 
-    inline int getctxopt (int option_) { return zmq_ctx_get (ptr, option_); }
+    inline int getctxopt(int option_) { return zmq_ctx_get(ptr, option_); }
 
-    inline ~context_t () ZMQ_NOTHROW { close (); }
+    inline ~context_t() ZMQ_NOTHROW { close(); }
 
-    inline void close () ZMQ_NOTHROW
+    inline void close() ZMQ_NOTHROW
     {
         if (ptr == NULL)
             return;
 
-        int rc = zmq_ctx_destroy (ptr);
-        ZMQ_ASSERT (rc == 0);
+        int rc = zmq_ctx_destroy(ptr);
+        ZMQ_ASSERT(rc == 0);
         ptr = NULL;
     }
 
     //  Be careful with this, it's probably only useful for
     //  using the C api together with an existing C++ api.
     //  Normally you should never need to use this.
-    inline ZMQ_EXPLICIT operator void * () ZMQ_NOTHROW { return ptr; }
+    inline ZMQ_EXPLICIT operator void *() ZMQ_NOTHROW { return ptr; }
 
-    inline ZMQ_EXPLICIT operator void const * () const ZMQ_NOTHROW
-    {
-        return ptr;
-    }
+    inline ZMQ_EXPLICIT operator void const *() const ZMQ_NOTHROW { return ptr; }
 
-    inline operator bool () const ZMQ_NOTHROW { return ptr != NULL; }
+    inline operator bool() const ZMQ_NOTHROW { return ptr != NULL; }
 
   private:
     void *ptr;
 
-    context_t (const context_t &) ZMQ_DELETED_FUNCTION;
-    void operator= (const context_t &) ZMQ_DELETED_FUNCTION;
+    context_t(const context_t &) ZMQ_DELETED_FUNCTION;
+    void operator=(const context_t &) ZMQ_DELETED_FUNCTION;
 };
 
 #ifdef ZMQ_CPP11
@@ -565,298 +547,285 @@ class socket_t
     friend class monitor_t;
 
   public:
-    inline socket_t (context_t &context_, int type_) { init (context_, type_); }
+    inline socket_t(context_t &context_, int type_) { init(context_, type_); }
 
 #ifdef ZMQ_CPP11
-    inline socket_t (context_t &context_, socket_type type_)
+    inline socket_t(context_t &context_, socket_type type_)
     {
-        init (context_, static_cast<int> (type_));
+        init(context_, static_cast<int>(type_));
     }
 #endif
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    inline socket_t (socket_t &&rhs) ZMQ_NOTHROW : ptr (rhs.ptr),
-                                                   ctxptr (rhs.ctxptr)
+    inline socket_t(socket_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr), ctxptr(rhs.ctxptr)
     {
         rhs.ptr = NULL;
         rhs.ctxptr = NULL;
     }
-    inline socket_t &operator= (socket_t &&rhs) ZMQ_NOTHROW
+    inline socket_t &operator=(socket_t &&rhs) ZMQ_NOTHROW
     {
-        std::swap (ptr, rhs.ptr);
+        std::swap(ptr, rhs.ptr);
         return *this;
     }
 #endif
 
-    inline ~socket_t () ZMQ_NOTHROW { close (); }
+    inline ~socket_t() ZMQ_NOTHROW { close(); }
 
-    inline operator void * () ZMQ_NOTHROW { return ptr; }
+    inline operator void *() ZMQ_NOTHROW { return ptr; }
 
-    inline operator void const * () const ZMQ_NOTHROW { return ptr; }
+    inline operator void const *() const ZMQ_NOTHROW { return ptr; }
 
-    inline void close () ZMQ_NOTHROW
+    inline void close() ZMQ_NOTHROW
     {
         if (ptr == NULL)
             // already closed
             return;
-        int rc = zmq_close (ptr);
-        ZMQ_ASSERT (rc == 0);
+        int rc = zmq_close(ptr);
+        ZMQ_ASSERT(rc == 0);
         ptr = 0;
     }
 
-    template <typename T> void setsockopt (int option_, T const &optval)
+    template<typename T> void setsockopt(int option_, T const &optval)
     {
-        setsockopt (option_, &optval, sizeof (T));
+        setsockopt(option_, &optval, sizeof(T));
     }
 
-    inline void setsockopt (int option_, const void *optval_, size_t optvallen_)
+    inline void setsockopt(int option_, const void *optval_, size_t optvallen_)
     {
-        int rc = zmq_setsockopt (ptr, option_, optval_, optvallen_);
+        int rc = zmq_setsockopt(ptr, option_, optval_, optvallen_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline void
-    getsockopt (int option_, void *optval_, size_t *optvallen_) const
+    inline void getsockopt(int option_, void *optval_, size_t *optvallen_) const
     {
-        int rc = zmq_getsockopt (ptr, option_, optval_, optvallen_);
+        int rc = zmq_getsockopt(ptr, option_, optval_, optvallen_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    template <typename T> T getsockopt (int option_) const
+    template<typename T> T getsockopt(int option_) const
     {
         T optval;
-        size_t optlen = sizeof (T);
-        getsockopt (option_, &optval, &optlen);
+        size_t optlen = sizeof(T);
+        getsockopt(option_, &optval, &optlen);
         return optval;
     }
 
-    inline void bind (std::string const &addr) { bind (addr.c_str ()); }
+    inline void bind(std::string const &addr) { bind(addr.c_str()); }
 
-    inline void bind (const char *addr_)
+    inline void bind(const char *addr_)
     {
-        int rc = zmq_bind (ptr, addr_);
+        int rc = zmq_bind(ptr, addr_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline void unbind (std::string const &addr) { unbind (addr.c_str ()); }
+    inline void unbind(std::string const &addr) { unbind(addr.c_str()); }
 
-    inline void unbind (const char *addr_)
+    inline void unbind(const char *addr_)
     {
-        int rc = zmq_unbind (ptr, addr_);
+        int rc = zmq_unbind(ptr, addr_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline void connect (std::string const &addr) { connect (addr.c_str ()); }
+    inline void connect(std::string const &addr) { connect(addr.c_str()); }
 
-    inline void connect (const char *addr_)
+    inline void connect(const char *addr_)
     {
-        int rc = zmq_connect (ptr, addr_);
+        int rc = zmq_connect(ptr, addr_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline void disconnect (std::string const &addr)
-    {
-        disconnect (addr.c_str ());
-    }
+    inline void disconnect(std::string const &addr) { disconnect(addr.c_str()); }
 
-    inline void disconnect (const char *addr_)
+    inline void disconnect(const char *addr_)
     {
-        int rc = zmq_disconnect (ptr, addr_);
+        int rc = zmq_disconnect(ptr, addr_);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
     }
 
-    inline bool connected () const ZMQ_NOTHROW { return (ptr != NULL); }
+    inline bool connected() const ZMQ_NOTHROW { return (ptr != NULL); }
 
-    inline size_t send (const void *buf_, size_t len_, int flags_ = 0)
+    inline size_t send(const void *buf_, size_t len_, int flags_ = 0)
     {
-        int nbytes = zmq_send (ptr, buf_, len_, flags_);
+        int nbytes = zmq_send(ptr, buf_, len_, flags_);
         if (nbytes >= 0)
             return (size_t) nbytes;
-        if (zmq_errno () == EAGAIN)
+        if (zmq_errno() == EAGAIN)
             return 0;
-        throw error_t ();
+        throw error_t();
     }
 
-    inline bool send (message_t &msg_, int flags_ = 0)
+    inline bool send(message_t &msg_, int flags_ = 0)
     {
-        int nbytes = zmq_msg_send (&(msg_.msg), ptr, flags_);
+        int nbytes = zmq_msg_send(&(msg_.msg), ptr, flags_);
         if (nbytes >= 0)
             return true;
-        if (zmq_errno () == EAGAIN)
+        if (zmq_errno() == EAGAIN)
             return false;
-        throw error_t ();
+        throw error_t();
     }
 
-    template <typename I> bool send (I first, I last, int flags_ = 0)
+    template<typename I> bool send(I first, I last, int flags_ = 0)
     {
-        zmq::message_t msg (first, last);
-        return send (msg, flags_);
+        zmq::message_t msg(first, last);
+        return send(msg, flags_);
     }
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    inline bool send (message_t &&msg_, int flags_ = 0)
-    {
-        return send (msg_, flags_);
-    }
+    inline bool send(message_t &&msg_, int flags_ = 0) { return send(msg_, flags_); }
 #endif
 
-    inline size_t recv (void *buf_, size_t len_, int flags_ = 0)
+    inline size_t recv(void *buf_, size_t len_, int flags_ = 0)
     {
-        int nbytes = zmq_recv (ptr, buf_, len_, flags_);
+        int nbytes = zmq_recv(ptr, buf_, len_, flags_);
         if (nbytes >= 0)
             return (size_t) nbytes;
-        if (zmq_errno () == EAGAIN)
+        if (zmq_errno() == EAGAIN)
             return 0;
-        throw error_t ();
+        throw error_t();
     }
 
-    inline bool recv (message_t *msg_, int flags_ = 0)
+    inline bool recv(message_t *msg_, int flags_ = 0)
     {
-        int nbytes = zmq_msg_recv (&(msg_->msg), ptr, flags_);
+        int nbytes = zmq_msg_recv(&(msg_->msg), ptr, flags_);
         if (nbytes >= 0)
             return true;
-        if (zmq_errno () == EAGAIN)
+        if (zmq_errno() == EAGAIN)
             return false;
-        throw error_t ();
+        throw error_t();
     }
 
   private:
-    inline void init (context_t &context_, int type_)
+    inline void init(context_t &context_, int type_)
     {
         ctxptr = context_.ptr;
-        ptr = zmq_socket (context_.ptr, type_);
+        ptr = zmq_socket(context_.ptr, type_);
         if (ptr == NULL)
-            throw error_t ();
+            throw error_t();
     }
 
     void *ptr;
     void *ctxptr;
 
-    socket_t (const socket_t &) ZMQ_DELETED_FUNCTION;
-    void operator= (const socket_t &) ZMQ_DELETED_FUNCTION;
+    socket_t(const socket_t &) ZMQ_DELETED_FUNCTION;
+    void operator=(const socket_t &) ZMQ_DELETED_FUNCTION;
 };
 
 class monitor_t
 {
   public:
-    monitor_t () : socketPtr (NULL), monitor_socket (NULL) {}
+    monitor_t() : socketPtr(NULL), monitor_socket(NULL) {}
 
-    virtual ~monitor_t ()
+    virtual ~monitor_t()
     {
         if (socketPtr)
-            zmq_socket_monitor (socketPtr, NULL, 0);
+            zmq_socket_monitor(socketPtr, NULL, 0);
 
         if (monitor_socket)
-            zmq_close (monitor_socket);
+            zmq_close(monitor_socket);
     }
 
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    monitor_t (monitor_t &&rhs) ZMQ_NOTHROW
-        : socketPtr (rhs.socketPtr),
-          monitor_socket (rhs.monitor_socket)
+    monitor_t(monitor_t &&rhs) ZMQ_NOTHROW : socketPtr(rhs.socketPtr),
+                                             monitor_socket(rhs.monitor_socket)
     {
         rhs.socketPtr = NULL;
         rhs.monitor_socket = NULL;
     }
 
-    socket_t &operator= (socket_t &&rhs) ZMQ_DELETED_FUNCTION;
+    socket_t &operator=(socket_t &&rhs) ZMQ_DELETED_FUNCTION;
 #endif
 
 
-    void monitor (socket_t &socket,
-                  std::string const &addr,
-                  int events = ZMQ_EVENT_ALL)
+    void
+    monitor(socket_t &socket, std::string const &addr, int events = ZMQ_EVENT_ALL)
     {
-        monitor (socket, addr.c_str (), events);
+        monitor(socket, addr.c_str(), events);
     }
 
-    void
-    monitor (socket_t &socket, const char *addr_, int events = ZMQ_EVENT_ALL)
+    void monitor(socket_t &socket, const char *addr_, int events = ZMQ_EVENT_ALL)
     {
-        init (socket, addr_, events);
+        init(socket, addr_, events);
         while (true) {
-            check_event (-1);
+            check_event(-1);
         }
     }
 
-    void
-    init (socket_t &socket, std::string const &addr, int events = ZMQ_EVENT_ALL)
+    void init(socket_t &socket, std::string const &addr, int events = ZMQ_EVENT_ALL)
     {
-        init (socket, addr.c_str (), events);
+        init(socket, addr.c_str(), events);
     }
 
-    void init (socket_t &socket, const char *addr_, int events = ZMQ_EVENT_ALL)
+    void init(socket_t &socket, const char *addr_, int events = ZMQ_EVENT_ALL)
     {
-        int rc = zmq_socket_monitor (socket.ptr, addr_, events);
+        int rc = zmq_socket_monitor(socket.ptr, addr_, events);
         if (rc != 0)
-            throw error_t ();
+            throw error_t();
 
         socketPtr = socket.ptr;
-        monitor_socket = zmq_socket (socket.ctxptr, ZMQ_PAIR);
-        assert (monitor_socket);
+        monitor_socket = zmq_socket(socket.ctxptr, ZMQ_PAIR);
+        assert(monitor_socket);
 
-        rc = zmq_connect (monitor_socket, addr_);
-        assert (rc == 0);
+        rc = zmq_connect(monitor_socket, addr_);
+        assert(rc == 0);
 
-        on_monitor_started ();
+        on_monitor_started();
     }
 
-    bool check_event (int timeout = 0)
+    bool check_event(int timeout = 0)
     {
-        assert (monitor_socket);
+        assert(monitor_socket);
 
         zmq_msg_t eventMsg;
-        zmq_msg_init (&eventMsg);
+        zmq_msg_init(&eventMsg);
 
         zmq::pollitem_t items[] = {
           {monitor_socket, 0, ZMQ_POLLIN, 0},
         };
 
-        zmq::poll (&items[0], 1, timeout);
+        zmq::poll(&items[0], 1, timeout);
 
         if (items[0].revents & ZMQ_POLLIN) {
-            int rc = zmq_msg_recv (&eventMsg, monitor_socket, 0);
-            if (rc == -1 && zmq_errno () == ETERM)
+            int rc = zmq_msg_recv(&eventMsg, monitor_socket, 0);
+            if (rc == -1 && zmq_errno() == ETERM)
                 return false;
-            assert (rc != -1);
+            assert(rc != -1);
 
         } else {
-            zmq_msg_close (&eventMsg);
+            zmq_msg_close(&eventMsg);
             return false;
         }
 
 #if ZMQ_VERSION_MAJOR >= 4
-        const char *data = static_cast<const char *> (zmq_msg_data (&eventMsg));
+        const char *data = static_cast<const char *>(zmq_msg_data(&eventMsg));
         zmq_event_t msgEvent;
-        memcpy (&msgEvent.event, data, sizeof (uint16_t));
-        data += sizeof (uint16_t);
-        memcpy (&msgEvent.value, data, sizeof (int32_t));
+        memcpy(&msgEvent.event, data, sizeof(uint16_t));
+        data += sizeof(uint16_t);
+        memcpy(&msgEvent.value, data, sizeof(int32_t));
         zmq_event_t *event = &msgEvent;
 #else
-        zmq_event_t *event =
-          static_cast<zmq_event_t *> (zmq_msg_data (&eventMsg));
+        zmq_event_t *event = static_cast<zmq_event_t *>(zmq_msg_data(&eventMsg));
 #endif
 
 #ifdef ZMQ_NEW_MONITOR_EVENT_LAYOUT
         zmq_msg_t addrMsg;
-        zmq_msg_init (&addrMsg);
-        int rc = zmq_msg_recv (&addrMsg, monitor_socket, 0);
-        if (rc == -1 && zmq_errno () == ETERM) {
-            zmq_msg_close (&eventMsg);
+        zmq_msg_init(&addrMsg);
+        int rc = zmq_msg_recv(&addrMsg, monitor_socket, 0);
+        if (rc == -1 && zmq_errno() == ETERM) {
+            zmq_msg_close(&eventMsg);
             return false;
         }
 
-        assert (rc != -1);
-        const char *str = static_cast<const char *> (zmq_msg_data (&addrMsg));
-        std::string address (str, str + zmq_msg_size (&addrMsg));
-        zmq_msg_close (&addrMsg);
+        assert(rc != -1);
+        const char *str = static_cast<const char *>(zmq_msg_data(&addrMsg));
+        std::string address(str, str + zmq_msg_size(&addrMsg));
+        zmq_msg_close(&addrMsg);
 #else
         // Bit of a hack, but all events in the zmq_event_t union have the same layout so this will work for all event types.
         std::string address = event->data.connected.addr;
@@ -864,7 +833,7 @@ class monitor_t
 
 #ifdef ZMQ_EVENT_MONITOR_STOPPED
         if (event->event == ZMQ_EVENT_MONITOR_STOPPED) {
-            zmq_msg_close (&eventMsg);
+            zmq_msg_close(&eventMsg);
             return true;
         }
 
@@ -872,262 +841,252 @@ class monitor_t
 
         switch (event->event) {
             case ZMQ_EVENT_CONNECTED:
-                on_event_connected (*event, address.c_str ());
+                on_event_connected(*event, address.c_str());
                 break;
             case ZMQ_EVENT_CONNECT_DELAYED:
-                on_event_connect_delayed (*event, address.c_str ());
+                on_event_connect_delayed(*event, address.c_str());
                 break;
             case ZMQ_EVENT_CONNECT_RETRIED:
-                on_event_connect_retried (*event, address.c_str ());
+                on_event_connect_retried(*event, address.c_str());
                 break;
             case ZMQ_EVENT_LISTENING:
-                on_event_listening (*event, address.c_str ());
+                on_event_listening(*event, address.c_str());
                 break;
             case ZMQ_EVENT_BIND_FAILED:
-                on_event_bind_failed (*event, address.c_str ());
+                on_event_bind_failed(*event, address.c_str());
                 break;
             case ZMQ_EVENT_ACCEPTED:
-                on_event_accepted (*event, address.c_str ());
+                on_event_accepted(*event, address.c_str());
                 break;
             case ZMQ_EVENT_ACCEPT_FAILED:
-                on_event_accept_failed (*event, address.c_str ());
+                on_event_accept_failed(*event, address.c_str());
                 break;
             case ZMQ_EVENT_CLOSED:
-                on_event_closed (*event, address.c_str ());
+                on_event_closed(*event, address.c_str());
                 break;
             case ZMQ_EVENT_CLOSE_FAILED:
-                on_event_close_failed (*event, address.c_str ());
+                on_event_close_failed(*event, address.c_str());
                 break;
             case ZMQ_EVENT_DISCONNECTED:
-                on_event_disconnected (*event, address.c_str ());
+                on_event_disconnected(*event, address.c_str());
                 break;
 #ifdef ZMQ_BUILD_DRAFT_API
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 3)
             case ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL:
-                on_event_handshake_failed_no_detail (*event, address.c_str ());
+                on_event_handshake_failed_no_detail(*event, address.c_str());
                 break;
             case ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL:
-                on_event_handshake_failed_protocol (*event, address.c_str ());
+                on_event_handshake_failed_protocol(*event, address.c_str());
                 break;
             case ZMQ_EVENT_HANDSHAKE_FAILED_AUTH:
-                on_event_handshake_failed_auth (*event, address.c_str ());
+                on_event_handshake_failed_auth(*event, address.c_str());
                 break;
             case ZMQ_EVENT_HANDSHAKE_SUCCEEDED:
-                on_event_handshake_succeeded (*event, address.c_str ());
+                on_event_handshake_succeeded(*event, address.c_str());
                 break;
 #elif ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 1)
             case ZMQ_EVENT_HANDSHAKE_FAILED:
-                on_event_handshake_failed (*event, address.c_str ());
+                on_event_handshake_failed(*event, address.c_str());
                 break;
             case ZMQ_EVENT_HANDSHAKE_SUCCEED:
-                on_event_handshake_succeed (*event, address.c_str ());
+                on_event_handshake_succeed(*event, address.c_str());
                 break;
 #endif
 #endif
             default:
-                on_event_unknown (*event, address.c_str ());
+                on_event_unknown(*event, address.c_str());
                 break;
         }
-        zmq_msg_close (&eventMsg);
+        zmq_msg_close(&eventMsg);
 
         return true;
     }
 
 #ifdef ZMQ_EVENT_MONITOR_STOPPED
-    void abort ()
+    void abort()
     {
         if (socketPtr)
-            zmq_socket_monitor (socketPtr, NULL, 0);
+            zmq_socket_monitor(socketPtr, NULL, 0);
 
         if (monitor_socket)
-            zmq_close (monitor_socket);
+            zmq_close(monitor_socket);
 
         socketPtr = NULL;
         monitor_socket = NULL;
     }
 #endif
-    virtual void on_monitor_started () {}
-    virtual void on_event_connected (const zmq_event_t &event_,
-                                     const char *addr_)
+    virtual void on_monitor_started() {}
+    virtual void on_event_connected(const zmq_event_t &event_, const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_connect_delayed (const zmq_event_t &event_,
-                                           const char *addr_)
+    virtual void on_event_connect_delayed(const zmq_event_t &event_,
+                                          const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_connect_retried (const zmq_event_t &event_,
-                                           const char *addr_)
+    virtual void on_event_connect_retried(const zmq_event_t &event_,
+                                          const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_listening (const zmq_event_t &event_,
-                                     const char *addr_)
+    virtual void on_event_listening(const zmq_event_t &event_, const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_bind_failed (const zmq_event_t &event_,
-                                       const char *addr_)
+    virtual void on_event_bind_failed(const zmq_event_t &event_, const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_accepted (const zmq_event_t &event_,
-                                    const char *addr_)
+    virtual void on_event_accepted(const zmq_event_t &event_, const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_accept_failed (const zmq_event_t &event_,
-                                         const char *addr_)
+    virtual void on_event_accept_failed(const zmq_event_t &event_, const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_closed (const zmq_event_t &event_, const char *addr_)
+    virtual void on_event_closed(const zmq_event_t &event_, const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_close_failed (const zmq_event_t &event_,
-                                        const char *addr_)
+    virtual void on_event_close_failed(const zmq_event_t &event_, const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_disconnected (const zmq_event_t &event_,
-                                        const char *addr_)
+    virtual void on_event_disconnected(const zmq_event_t &event_, const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 3)
-    virtual void on_event_handshake_failed_no_detail (const zmq_event_t &event_,
-                                                      const char *addr_)
-    {
-        (void) event_;
-        (void) addr_;
-    }
-    virtual void on_event_handshake_failed_protocol (const zmq_event_t &event_,
+    virtual void on_event_handshake_failed_no_detail(const zmq_event_t &event_,
                                                      const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_handshake_failed_auth (const zmq_event_t &event_,
-                                                 const char *addr_)
+    virtual void on_event_handshake_failed_protocol(const zmq_event_t &event_,
+                                                    const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_handshake_succeeded (const zmq_event_t &event_,
-                                               const char *addr_)
+    virtual void on_event_handshake_failed_auth(const zmq_event_t &event_,
+                                                const char *addr_)
+    {
+        (void) event_;
+        (void) addr_;
+    }
+    virtual void on_event_handshake_succeeded(const zmq_event_t &event_,
+                                              const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
 #elif ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 1)
-    virtual void on_event_handshake_failed (const zmq_event_t &event_,
+    virtual void on_event_handshake_failed(const zmq_event_t &event_,
+                                           const char *addr_)
+    {
+        (void) event_;
+        (void) addr_;
+    }
+    virtual void on_event_handshake_succeed(const zmq_event_t &event_,
                                             const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
-    virtual void on_event_handshake_succeed (const zmq_event_t &event_,
-                                             const char *addr_)
-    {
-        (void) event_;
-        (void) addr_;
-    }
 #endif
-    virtual void on_event_unknown (const zmq_event_t &event_, const char *addr_)
+    virtual void on_event_unknown(const zmq_event_t &event_, const char *addr_)
     {
         (void) event_;
         (void) addr_;
     }
 
   private:
-    monitor_t (const monitor_t &) ZMQ_DELETED_FUNCTION;
-    void operator= (const monitor_t &) ZMQ_DELETED_FUNCTION;
+    monitor_t(const monitor_t &) ZMQ_DELETED_FUNCTION;
+    void operator=(const monitor_t &) ZMQ_DELETED_FUNCTION;
 
     void *socketPtr;
     void *monitor_socket;
 };
 
-#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)                         \
-  && defined(ZMQ_HAVE_POLLER)
-template <typename T = void> class poller_t
+#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11) && defined(ZMQ_HAVE_POLLER)
+template<typename T = void> class poller_t
 {
   public:
-    void add (zmq::socket_t &socket, short events, T *user_data)
+    void add(zmq::socket_t &socket, short events, T *user_data)
     {
         if (0
-            != zmq_poller_add (poller_ptr.get (), static_cast<void *> (socket),
-                               user_data, events)) {
-            throw error_t ();
+            != zmq_poller_add(poller_ptr.get(), static_cast<void *>(socket),
+                              user_data, events)) {
+            throw error_t();
         }
     }
 
-    void remove (zmq::socket_t &socket)
+    void remove(zmq::socket_t &socket)
     {
-        if (0
-            != zmq_poller_remove (poller_ptr.get (),
-                                  static_cast<void *> (socket))) {
-            throw error_t ();
+        if (0 != zmq_poller_remove(poller_ptr.get(), static_cast<void *>(socket))) {
+            throw error_t();
         }
     }
 
-    void modify (zmq::socket_t &socket, short events)
+    void modify(zmq::socket_t &socket, short events)
     {
         if (0
-            != zmq_poller_modify (poller_ptr.get (),
-                                  static_cast<void *> (socket), events)) {
-            throw error_t ();
+            != zmq_poller_modify(poller_ptr.get(), static_cast<void *>(socket),
+                                 events)) {
+            throw error_t();
         }
     }
 
-    size_t wait_all (std::vector<zmq_poller_event_t> &poller_events,
-                     const std::chrono::microseconds timeout)
+    size_t wait_all(std::vector<zmq_poller_event_t> &poller_events,
+                    const std::chrono::microseconds timeout)
     {
-        int rc = zmq_poller_wait_all (poller_ptr.get (), poller_events.data (),
-                                      static_cast<int> (poller_events.size ()),
-                                      static_cast<long> (timeout.count ()));
+        int rc = zmq_poller_wait_all(poller_ptr.get(), poller_events.data(),
+                                     static_cast<int>(poller_events.size()),
+                                     static_cast<long>(timeout.count()));
         if (rc > 0)
-            return static_cast<size_t> (rc);
+            return static_cast<size_t>(rc);
 
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 3)
-        if (zmq_errno () == EAGAIN)
+        if (zmq_errno() == EAGAIN)
 #else
-        if (zmq_errno () == ETIMEDOUT)
+        if (zmq_errno() == ETIMEDOUT)
 #endif
             return 0;
 
-        throw error_t ();
+        throw error_t();
     }
 
   private:
     std::unique_ptr<void, std::function<void(void *)>> poller_ptr{
       []() {
-          auto poller_new = zmq_poller_new ();
+          auto poller_new = zmq_poller_new();
           if (poller_new)
               return poller_new;
-          throw error_t ();
+          throw error_t();
       }(),
       [](void *ptr) {
-          int rc = zmq_poller_destroy (&ptr);
-          ZMQ_ASSERT (rc == 0);
+          int rc = zmq_poller_destroy(&ptr);
+          ZMQ_ASSERT(rc == 0);
       }};
 };
 #endif //  defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11) && defined(ZMQ_HAVE_POLLER)
 
-inline std::ostream &operator<< (std::ostream &os, const message_t &msg)
+inline std::ostream &operator<<(std::ostream &os, const message_t &msg)
 {
-    return os << msg.str ();
+    return os << msg.str();
 }
 
 } // namespace zmq

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -52,252 +52,246 @@ class multipart_t
     typedef std::deque<message_t>::const_iterator const_iterator;
 
     typedef std::deque<message_t>::reverse_iterator reverse_iterator;
-    typedef std::deque<message_t>::const_reverse_iterator
-      const_reverse_iterator;
+    typedef std::deque<message_t>::const_reverse_iterator const_reverse_iterator;
 
     // Default constructor
-    multipart_t () {}
+    multipart_t() {}
 
     // Construct from socket receive
-    multipart_t (socket_t &socket) { recv (socket); }
+    multipart_t(socket_t &socket) { recv(socket); }
 
     // Construct from memory block
-    multipart_t (const void *src, size_t size) { addmem (src, size); }
+    multipart_t(const void *src, size_t size) { addmem(src, size); }
 
     // Construct from string
-    multipart_t (const std::string &string) { addstr (string); }
+    multipart_t(const std::string &string) { addstr(string); }
 
     // Construct from message part
-    multipart_t (message_t &&message) { add (std::move (message)); }
+    multipart_t(message_t &&message) { add(std::move(message)); }
 
     // Move constructor
-    multipart_t (multipart_t &&other) { m_parts = std::move (other.m_parts); }
+    multipart_t(multipart_t &&other) { m_parts = std::move(other.m_parts); }
 
     // Move assignment operator
-    multipart_t &operator= (multipart_t &&other)
+    multipart_t &operator=(multipart_t &&other)
     {
-        m_parts = std::move (other.m_parts);
+        m_parts = std::move(other.m_parts);
         return *this;
     }
 
     // Destructor
-    virtual ~multipart_t () { clear (); }
+    virtual ~multipart_t() { clear(); }
 
-    message_t &operator[] (size_t n) { return m_parts[n]; }
+    message_t &operator[](size_t n) { return m_parts[n]; }
 
-    const message_t &operator[] (size_t n) const { return m_parts[n]; }
+    const message_t &operator[](size_t n) const { return m_parts[n]; }
 
-    message_t &at (size_t n) { return m_parts.at (n); }
+    message_t &at(size_t n) { return m_parts.at(n); }
 
-    const message_t &at (size_t n) const { return m_parts.at (n); }
+    const message_t &at(size_t n) const { return m_parts.at(n); }
 
-    iterator begin () { return m_parts.begin (); }
+    iterator begin() { return m_parts.begin(); }
 
-    const_iterator begin () const { return m_parts.begin (); }
+    const_iterator begin() const { return m_parts.begin(); }
 
-    const_iterator cbegin () const { return m_parts.cbegin (); }
+    const_iterator cbegin() const { return m_parts.cbegin(); }
 
-    reverse_iterator rbegin () { return m_parts.rbegin (); }
+    reverse_iterator rbegin() { return m_parts.rbegin(); }
 
-    const_reverse_iterator rbegin () const { return m_parts.rbegin (); }
+    const_reverse_iterator rbegin() const { return m_parts.rbegin(); }
 
-    iterator end () { return m_parts.end (); }
+    iterator end() { return m_parts.end(); }
 
-    const_iterator end () const { return m_parts.end (); }
+    const_iterator end() const { return m_parts.end(); }
 
-    const_iterator cend () const { return m_parts.cend (); }
+    const_iterator cend() const { return m_parts.cend(); }
 
-    reverse_iterator rend () { return m_parts.rend (); }
+    reverse_iterator rend() { return m_parts.rend(); }
 
-    const_reverse_iterator rend () const { return m_parts.rend (); }
+    const_reverse_iterator rend() const { return m_parts.rend(); }
 
     // Delete all parts
-    void clear () { m_parts.clear (); }
+    void clear() { m_parts.clear(); }
 
     // Get number of parts
-    size_t size () const { return m_parts.size (); }
+    size_t size() const { return m_parts.size(); }
 
     // Check if number of parts is zero
-    bool empty () const { return m_parts.empty (); }
+    bool empty() const { return m_parts.empty(); }
 
     // Receive multipart message from socket
-    bool recv (socket_t &socket, int flags = 0)
+    bool recv(socket_t &socket, int flags = 0)
     {
-        clear ();
+        clear();
         bool more = true;
         while (more) {
             message_t message;
-            if (!socket.recv (&message, flags))
+            if (!socket.recv(&message, flags))
                 return false;
-            more = message.more ();
-            add (std::move (message));
+            more = message.more();
+            add(std::move(message));
         }
         return true;
     }
 
     // Send multipart message to socket
-    bool send (socket_t &socket, int flags = 0)
+    bool send(socket_t &socket, int flags = 0)
     {
         flags &= ~(ZMQ_SNDMORE);
-        bool more = size () > 0;
+        bool more = size() > 0;
         while (more) {
-            message_t message = pop ();
-            more = size () > 0;
-            if (!socket.send (message, (more ? ZMQ_SNDMORE : 0) | flags))
+            message_t message = pop();
+            more = size() > 0;
+            if (!socket.send(message, (more ? ZMQ_SNDMORE : 0) | flags))
                 return false;
         }
-        clear ();
+        clear();
         return true;
     }
 
     // Concatenate other multipart to front
-    void prepend (multipart_t &&other)
+    void prepend(multipart_t &&other)
     {
-        while (!other.empty ())
-            push (other.remove ());
+        while (!other.empty())
+            push(other.remove());
     }
 
     // Concatenate other multipart to back
-    void append (multipart_t &&other)
+    void append(multipart_t &&other)
     {
-        while (!other.empty ())
-            add (other.pop ());
+        while (!other.empty())
+            add(other.pop());
     }
 
     // Push memory block to front
-    void pushmem (const void *src, size_t size)
+    void pushmem(const void *src, size_t size)
     {
-        m_parts.push_front (message_t (src, size));
+        m_parts.push_front(message_t(src, size));
     }
 
     // Push memory block to back
-    void addmem (const void *src, size_t size)
+    void addmem(const void *src, size_t size)
     {
-        m_parts.push_back (message_t (src, size));
+        m_parts.push_back(message_t(src, size));
     }
 
     // Push string to front
-    void pushstr (const std::string &string)
+    void pushstr(const std::string &string)
     {
-        m_parts.push_front (message_t (string.data (), string.size ()));
+        m_parts.push_front(message_t(string.data(), string.size()));
     }
 
     // Push string to back
-    void addstr (const std::string &string)
+    void addstr(const std::string &string)
     {
-        m_parts.push_back (message_t (string.data (), string.size ()));
+        m_parts.push_back(message_t(string.data(), string.size()));
     }
 
     // Push type (fixed-size) to front
-    template <typename T> void pushtyp (const T &type)
+    template<typename T> void pushtyp(const T &type)
     {
-        static_assert (!std::is_same<T, std::string>::value,
-                       "Use pushstr() instead of pushtyp<std::string>()");
-        m_parts.push_front (message_t (&type, sizeof (type)));
+        static_assert(!std::is_same<T, std::string>::value,
+                      "Use pushstr() instead of pushtyp<std::string>()");
+        m_parts.push_front(message_t(&type, sizeof(type)));
     }
 
     // Push type (fixed-size) to back
-    template <typename T> void addtyp (const T &type)
+    template<typename T> void addtyp(const T &type)
     {
-        static_assert (!std::is_same<T, std::string>::value,
-                       "Use addstr() instead of addtyp<std::string>()");
-        m_parts.push_back (message_t (&type, sizeof (type)));
+        static_assert(!std::is_same<T, std::string>::value,
+                      "Use addstr() instead of addtyp<std::string>()");
+        m_parts.push_back(message_t(&type, sizeof(type)));
     }
 
     // Push message part to front
-    void push (message_t &&message)
-    {
-        m_parts.push_front (std::move (message));
-    }
+    void push(message_t &&message) { m_parts.push_front(std::move(message)); }
 
     // Push message part to back
-    void add (message_t &&message) { m_parts.push_back (std::move (message)); }
+    void add(message_t &&message) { m_parts.push_back(std::move(message)); }
 
     // Pop string from front
-    std::string popstr ()
+    std::string popstr()
     {
-        std::string string (m_parts.front ().data<char> (),
-                            m_parts.front ().size ());
-        m_parts.pop_front ();
+        std::string string(m_parts.front().data<char>(), m_parts.front().size());
+        m_parts.pop_front();
         return string;
     }
 
     // Pop type (fixed-size) from front
-    template <typename T> T poptyp ()
+    template<typename T> T poptyp()
     {
-        static_assert (!std::is_same<T, std::string>::value,
-                       "Use popstr() instead of poptyp<std::string>()");
-        if (sizeof (T) != m_parts.front ().size ())
-            throw std::runtime_error (
+        static_assert(!std::is_same<T, std::string>::value,
+                      "Use popstr() instead of poptyp<std::string>()");
+        if (sizeof(T) != m_parts.front().size())
+            throw std::runtime_error(
               "Invalid type, size does not match the message size");
-        T type = *m_parts.front ().data<T> ();
-        m_parts.pop_front ();
+        T type = *m_parts.front().data<T>();
+        m_parts.pop_front();
         return type;
     }
 
     // Pop message part from front
-    message_t pop ()
+    message_t pop()
     {
-        message_t message = std::move (m_parts.front ());
-        m_parts.pop_front ();
+        message_t message = std::move(m_parts.front());
+        m_parts.pop_front();
         return message;
     }
 
     // Pop message part from back
-    message_t remove ()
+    message_t remove()
     {
-        message_t message = std::move (m_parts.back ());
-        m_parts.pop_back ();
+        message_t message = std::move(m_parts.back());
+        m_parts.pop_back();
         return message;
     }
 
     // Get pointer to a specific message part
-    const message_t *peek (size_t index) const { return &m_parts[index]; }
+    const message_t *peek(size_t index) const { return &m_parts[index]; }
 
     // Get a string copy of a specific message part
-    std::string peekstr (size_t index) const
+    std::string peekstr(size_t index) const
     {
-        std::string string (m_parts[index].data<char> (),
-                            m_parts[index].size ());
+        std::string string(m_parts[index].data<char>(), m_parts[index].size());
         return string;
     }
 
     // Peek type (fixed-size) from front
-    template <typename T> T peektyp (size_t index) const
+    template<typename T> T peektyp(size_t index) const
     {
-        static_assert (!std::is_same<T, std::string>::value,
-                       "Use peekstr() instead of peektyp<std::string>()");
-        if (sizeof (T) != m_parts[index].size ())
-            throw std::runtime_error (
+        static_assert(!std::is_same<T, std::string>::value,
+                      "Use peekstr() instead of peektyp<std::string>()");
+        if (sizeof(T) != m_parts[index].size())
+            throw std::runtime_error(
               "Invalid type, size does not match the message size");
-        T type = *m_parts[index].data<T> ();
+        T type = *m_parts[index].data<T>();
         return type;
     }
 
     // Create multipart from type (fixed-size)
-    template <typename T> static multipart_t create (const T &type)
+    template<typename T> static multipart_t create(const T &type)
     {
         multipart_t multipart;
-        multipart.addtyp (type);
+        multipart.addtyp(type);
         return multipart;
     }
 
     // Copy multipart
-    multipart_t clone () const
+    multipart_t clone() const
     {
         multipart_t multipart;
-        for (size_t i = 0; i < size (); i++)
-            multipart.addmem (m_parts[i].data (), m_parts[i].size ());
+        for (size_t i = 0; i < size(); i++)
+            multipart.addmem(m_parts[i].data(), m_parts[i].size());
         return multipart;
     }
 
     // Dump content to string
-    std::string str () const
+    std::string str() const
     {
         std::stringstream ss;
-        for (size_t i = 0; i < m_parts.size (); i++) {
-            const unsigned char *data = m_parts[i].data<unsigned char> ();
-            size_t size = m_parts[i].size ();
+        for (size_t i = 0; i < m_parts.size(); i++) {
+            const unsigned char *data = m_parts[i].data<unsigned char>();
+            size_t size = m_parts[i].size();
 
             // Dump the message as text or binary
             bool isText = true;
@@ -307,121 +301,119 @@ class multipart_t
                     break;
                 }
             }
-            ss << "\n[" << std::dec << std::setw (3) << std::setfill ('0')
-               << size << "] ";
+            ss << "\n[" << std::dec << std::setw(3) << std::setfill('0') << size
+               << "] ";
             if (size >= 1000) {
                 ss << "... (to big to print)";
                 continue;
             }
             for (size_t j = 0; j < size; j++) {
                 if (isText)
-                    ss << static_cast<char> (data[j]);
+                    ss << static_cast<char>(data[j]);
                 else
-                    ss << std::hex << std::setw (2) << std::setfill ('0')
-                       << static_cast<short> (data[j]);
+                    ss << std::hex << std::setw(2) << std::setfill('0')
+                       << static_cast<short>(data[j]);
             }
         }
-        return ss.str ();
+        return ss.str();
     }
 
     // Check if equal to other multipart
-    bool equal (const multipart_t *other) const
+    bool equal(const multipart_t *other) const
     {
-        if (size () != other->size ())
+        if (size() != other->size())
             return false;
-        for (size_t i = 0; i < size (); i++)
-            if (*peek (i) != *other->peek (i))
+        for (size_t i = 0; i < size(); i++)
+            if (*peek(i) != *other->peek(i))
                 return false;
         return true;
     }
 
   private:
     // Disable implicit copying (moving is more efficient)
-    multipart_t (const multipart_t &other) ZMQ_DELETED_FUNCTION;
-    void operator= (const multipart_t &other) ZMQ_DELETED_FUNCTION;
+    multipart_t(const multipart_t &other) ZMQ_DELETED_FUNCTION;
+    void operator=(const multipart_t &other) ZMQ_DELETED_FUNCTION;
 }; // class multipart_t
 
-inline std::ostream &operator<< (std::ostream &os, const multipart_t &msg)
+inline std::ostream &operator<<(std::ostream &os, const multipart_t &msg)
 {
-    return os << msg.str ();
+    return os << msg.str();
 }
 
 #endif // ZMQ_HAS_RVALUE_REFS
 
-#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)                         \
-  && defined(ZMQ_HAVE_POLLER)
+#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11) && defined(ZMQ_HAVE_POLLER)
 class active_poller_t
 {
   public:
-    active_poller_t () = default;
-    ~active_poller_t () = default;
+    active_poller_t() = default;
+    ~active_poller_t() = default;
 
-    active_poller_t (const active_poller_t &) = delete;
-    active_poller_t &operator= (const active_poller_t &) = delete;
+    active_poller_t(const active_poller_t &) = delete;
+    active_poller_t &operator=(const active_poller_t &) = delete;
 
-    active_poller_t (active_poller_t &&src) = default;
-    active_poller_t &operator= (active_poller_t &&src) = default;
+    active_poller_t(active_poller_t &&src) = default;
+    active_poller_t &operator=(active_poller_t &&src) = default;
 
     using handler_t = std::function<void(short)>;
 
-    void add (zmq::socket_t &socket, short events, handler_t handler)
+    void add(zmq::socket_t &socket, short events, handler_t handler)
     {
-        auto it = decltype (handlers)::iterator{};
+        auto it = decltype(handlers)::iterator{};
         auto inserted = bool{};
-        std::tie (it, inserted) =
-          handlers.emplace (static_cast<void *> (socket),
-                            std::make_shared<handler_t> (std::move (handler)));
+        std::tie(it, inserted) =
+          handlers.emplace(static_cast<void *>(socket),
+                           std::make_shared<handler_t>(std::move(handler)));
         try {
-            base_poller.add (socket, events,
-                             inserted && *(it->second) ? it->second.get ()
-                                                       : nullptr);
+            base_poller.add(socket, events,
+                            inserted && *(it->second) ? it->second.get() : nullptr);
             need_rebuild |= inserted;
         }
         catch (const zmq::error_t &) {
             // rollback
             if (inserted) {
-                handlers.erase (static_cast<void *> (socket));
+                handlers.erase(static_cast<void *>(socket));
             }
             throw;
         }
     }
 
-    void remove (zmq::socket_t &socket)
+    void remove(zmq::socket_t &socket)
     {
-        base_poller.remove (socket);
-        handlers.erase (static_cast<void *> (socket));
+        base_poller.remove(socket);
+        handlers.erase(static_cast<void *>(socket));
         need_rebuild = true;
     }
 
-    void modify (zmq::socket_t &socket, short events)
+    void modify(zmq::socket_t &socket, short events)
     {
-        base_poller.modify (socket, events);
+        base_poller.modify(socket, events);
     }
 
-    size_t wait (std::chrono::milliseconds timeout)
+    size_t wait(std::chrono::milliseconds timeout)
     {
         if (need_rebuild) {
-            poller_events.resize (handlers.size ());
-            poller_handlers.clear ();
-            poller_handlers.reserve (handlers.size ());
+            poller_events.resize(handlers.size());
+            poller_handlers.clear();
+            poller_handlers.reserve(handlers.size());
             for (const auto &handler : handlers) {
-                poller_handlers.push_back (handler.second);
+                poller_handlers.push_back(handler.second);
             }
             need_rebuild = false;
         }
-        const auto count = base_poller.wait_all (poller_events, timeout);
-        std::for_each (poller_events.begin (), poller_events.begin () + count,
-                       [](zmq_poller_event_t &event) {
-                           if (event.user_data != NULL)
-                               (*reinterpret_cast<handler_t *> (
-                                 event.user_data)) (event.events);
-                       });
+        const auto count = base_poller.wait_all(poller_events, timeout);
+        std::for_each(poller_events.begin(), poller_events.begin() + count,
+                      [](zmq_poller_event_t &event) {
+                          if (event.user_data != NULL)
+                              (*reinterpret_cast<handler_t *>(event.user_data))(
+                                event.events);
+                      });
         return count;
     }
 
-    bool empty () const { return handlers.empty (); }
+    bool empty() const { return handlers.empty(); }
 
-    size_t size () const { return handlers.size (); }
+    size_t size() const { return handlers.size(); }
 
   private:
     bool need_rebuild{false};


### PR DESCRIPTION
For header only library like cppzmq, whitespace style inherited from
libzmq is too restrictive.

Solution: relaxing whitespace before parens from always to in control
statements only, increased max column width from 80 to 85 and removing
requirement of whitespace after template keyword.