### PR TITLE
Problem: OSX build not enabled in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,15 @@ env:
 
 matrix:
   include:
+    ##########################################################
+    # Clang on OSX
+    # Travis takes longer to start OSX instances,
+    # so leaving it first for the overall build to be faster.
+    ##########################################################
+    - os: osx
+      osx_image: xcode9.1
+      env:
+        - MATRIX_EVAL="brew install cmake" ZMQ_VERSION=4.2.5 DRAFT=1
   # - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=/usr/local/clang-5.0.0/bin/clang-format
     # os: linux
     # addons:
@@ -39,10 +48,6 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ZMQ_VERSION=4.2.5 DRAFT=1
-    - os: osx
-      osx_image: xcode8
-      env:
-        - MATRIX_EVAL="brew install cmake gcc && CC=gcc-7 && CXX=g++-7" ZMQ_VERSION=4.2.5 DRAFT=1
 
 sudo: required
 
@@ -52,6 +57,7 @@ before_install:
 # Build and check this project
 script:
   - eval "${MATRIX_EVAL}"
+  - cmake --version
   - ./ci_build.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ addons:
 
 env:
   matrix:
-#    - BUILD_TYPE=cmake DRAFT=enabled
-    - BUILD_TYPE=cmake ZMQ_VERSION=4.2.5
-    - BUILD_TYPE=cmake ZMQ_VERSION=4.2.0
+#    - ZMQ_BUILD_TYPE=cmake DRAFT=enabled
+    - ZMQ_BUILD_TYPE=cmake ZMQ_VERSION=4.2.5
+    - ZMQ_BUILD_TYPE=pkgconf ZMQ_VERSION=4.2.0
 
 matrix:
   include:
-  # - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=/usr/local/clang-5.0.0/bin/clang-format
+  # - env: ZMQ_BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=/usr/local/clang-5.0.0/bin/clang-format
     # os: linux
     # addons:
     # apt:
@@ -39,15 +39,15 @@ matrix:
           packages:
             - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" BUILD_TYPE=cmake ZMQ_VERSION=4.2.5 DRAFT=1
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ZMQ_BUILD_TYPE=cmake ZMQ_VERSION=4.2.5 DRAFT=1
 
 sudo: required
 
 before_install:
   - pip install --user cpp-coveralls
-  
-# Build and check this project according to the BUILD_TYPE
-script:     
+
+# Build and check this project according to the ZMQ_BUILD_TYPE
+script:
   - eval "${MATRIX_EVAL}"
   - ./ci_build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ZMQ_VERSION=4.2.5 DRAFT=1
+    - os: osx
+      osx_image: xcode8
+      env:
+        - MATRIX_EVAL="brew install cmake gcc && CC=gcc-7 && CXX=g++-7" ZMQ_VERSION=4.2.5 DRAFT=1
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,8 @@
 
 language: cpp
 
-os:
-- linux
-#- osx
-
 dist: trusty
-
 cache: ccache
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ matrix:
 
     - os: osx
       osx_image: xcode9.1
-      env:
-        - MATRIX_EVAL="brew install cmake" ZMQ_VERSION=4.2.5 DRAFT=1
+      compiler: clang
+      env: ZMQ_VERSION=4.2.5 DRAFT=1
 
     ##########################################################
     # GCC on Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,10 @@ matrix:
       # packages:
         # - clang-5.0
 
-sudo: required
+sudo: false
 
 before_install:
-  - pip install --user cpp-coveralls
+  - pip install --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --user cpp-coveralls
 
 # Build and check this project
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
 sudo: false
 
 before_install:
-  - pip install --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --user cpp-coveralls
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install --user cpp-coveralls; fi
 
 # Build and check this project
 script:
@@ -71,4 +71,4 @@ script:
   - ./ci_build.sh
 
 after_success:
-  - coveralls --root . -E ".*external.*" -E ".*CMakeFiles.*" -E ".*tests/" -E ".*demo/" -E ".*libzmq/"
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then coveralls --root . -E ".*external.*" -E ".*CMakeFiles.*" -E ".*tests/" -E ".*demo/" -E ".*libzmq/"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
 
-env:
-  matrix:
-    - ZMQ_VERSION=4.2.5
-    - ZMQ_VERSION=4.2.4
-
 matrix:
   include:
     ##########################################################
@@ -27,18 +22,25 @@ matrix:
     # Travis takes longer to start OSX instances,
     # so leaving it first for the overall build to be faster.
     ##########################################################
+
     - os: osx
       osx_image: xcode9.1
       env:
         - MATRIX_EVAL="brew install cmake" ZMQ_VERSION=4.2.5 DRAFT=1
-  # - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=/usr/local/clang-5.0.0/bin/clang-format
-    # os: linux
-    # addons:
-    # apt:
-      # sources:
-        # - llvm-toolchain-trusty-5.0
-      # packages:
-        # - clang-5.0
+
+    ##########################################################
+    # GCC on Linux
+    ##########################################################
+
+    # GCC default, draft disabled, latest libzmq
+    - os: linux
+      env: ZMQ_VERSION=4.2.5
+
+    # GCC default, draft disabled,  older libzmq
+    - os: linux
+      env: ZMQ_VERSION=4.2.4
+
+    # GCC 7, draft enabled, latest libzmq
     - os: linux
       addons:
         apt:
@@ -48,6 +50,14 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ZMQ_VERSION=4.2.5 DRAFT=1
+  # - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=/usr/local/clang-5.0.0/bin/clang-format
+    # os: linux
+    # addons:
+    # apt:
+      # sources:
+        # - llvm-toolchain-trusty-5.0
+      # packages:
+        # - clang-5.0
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,12 @@ addons:
 
 env:
   matrix:
-#    - ZMQ_BUILD_TYPE=cmake DRAFT=enabled
-    - ZMQ_BUILD_TYPE=cmake ZMQ_VERSION=4.2.5
-    - ZMQ_BUILD_TYPE=pkgconf ZMQ_VERSION=4.2.0
+    - ZMQ_VERSION=4.2.5
+    - ZMQ_VERSION=4.2.4
 
 matrix:
   include:
-  # - env: ZMQ_BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=/usr/local/clang-5.0.0/bin/clang-format
+  # - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=/usr/local/clang-5.0.0/bin/clang-format
     # os: linux
     # addons:
     # apt:
@@ -39,14 +38,14 @@ matrix:
           packages:
             - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ZMQ_BUILD_TYPE=cmake ZMQ_VERSION=4.2.5 DRAFT=1
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ZMQ_VERSION=4.2.5 DRAFT=1
 
 sudo: required
 
 before_install:
   - pip install --user cpp-coveralls
 
-# Build and check this project according to the ZMQ_BUILD_TYPE
+# Build and check this project
 script:
   - eval "${MATRIX_EVAL}"
   - ./ci_build.sh

--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ Supported platforms
 
  - Only a subset of the platforms that are supported by libzmq itself are supported. Some features already require a compiler supporting C++11. In the future, probably all features will require C++11. To build and run the tests, cmake and googletest are required.
  - Tested libzmq versions are
-   - 4.2.0 (without DRAFT API)
+   - 4.2.4 (without DRAFT API)
    - 4.2.5 (with and without DRAFT API)
  - Platforms with full support (i.e. CI executing build and tests)
    - Ubuntu 14.04 x64 (with gcc 4.8.4) (without DRAFT API only)
    - Ubuntu 14.04 x64 (with gcc 7.3.0)
    - Visual Studio 2015 x86
    - Visual Studio 2017 x86
+   - OSX (with clang xcode9.1) (without DRAFT API)
  - Additional platforms that are known to work:
    - We have no current reports on additional platforms that are known to work yet. Please add your platform here. If CI can be provided for them with a cloud-based CI service working with GitHub, you are invited to add CI, and make it possible to be included in the list above.
  - Additional platforms that probably work:
    - Any platform supported by libzmq that provides a sufficiently recent gcc (4.8.1 or newer) or clang (3.3 or newer)
-   - MacOS X
    - Visual Studio 2012+ x86/x64
 
 Contribution policy
@@ -71,6 +71,7 @@ cpp zmq (which will also include libzmq for you).
 #find cppzmq wrapper, installed by make of cppzmq
 find_package(cppzmq)
 if(cppzmq_FOUND)
+    include_directories(${ZeroMQ_INCLUDE_DIR} ${cppzmq_INCLUDE_DIR})
     target_link_libraries(*Your Project Name* ${cppzmq_LIBRARY})
 endif()
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ cpp zmq (which will also include libzmq for you).
 #find cppzmq wrapper, installed by make of cppzmq
 find_package(cppzmq)
 if(cppzmq_FOUND)
-    include_directories(${ZeroMQ_INCLUDE_DIR} ${cppzmq_INCLUDE_DIR})
     target_link_libraries(*Your Project Name* ${cppzmq_LIBRARY})
 endif()
 ```

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -5,6 +5,8 @@ set -e
 
 LIBZMQ=${PWD}/libzmq-build
 CPPZMQ=${PWD}/cppzmq-build
+# Travis machines have 2 cores
+JOBS=2
 
 if [ "$DRAFT" = "1" ] ; then
     # if we enable drafts during the libzmq cmake build, the pkgconfig
@@ -21,7 +23,7 @@ install_zeromq() {
                                               -DZMQ_BUILD_TESTS=OFF \
                                               -DCMAKE_BUILD_TYPE=Release \
                                               ${ZEROMQ_CMAKE_FLAGS}
-    cmake --build ${LIBZMQ}
+    cmake --build ${LIBZMQ} -- -j${JOBS}
 }
 
 # build zeromq first
@@ -31,13 +33,13 @@ if [ "${ZMQ_VERSION}" != "" ] ; then install_zeromq ; fi
 # build cppzmq
 pushd .
 ZeroMQ_DIR=${LIBZMQ} cmake -H. -B${CPPZMQ} ${ZEROMQ_CMAKE_FLAGS}
-cmake --build ${CPPZMQ}
+cmake --build ${CPPZMQ} -- -j${JOBS}
 cd ${CPPZMQ}
-ctest -V
+ctest -V -j${JOBS}
 popd
 
 # build cppzmq demo
 ZeroMQ_DIR=${LIBZMQ} cppzmq_DIR=${CPPZMQ} cmake -Hdemo -Bdemo/build
 cmake --build demo/build
 cd demo/build
-ctest
+ctest -V

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -10,12 +10,17 @@ if [ "$DRAFT" = "1" ] ; then
     export ZEROMQ_CMAKE_FLAGS="-DENABLE_DRAFTS=ON"
 fi
 
+LIBZMQ=${PWD}/libzmq-build
+CPPZMQ=${PWD}/cppzmq-build
 install_zeromq() {
     curl -L https://github.com/zeromq/libzmq/archive/v${ZMQ_VERSION}.tar.gz \
       >zeromq.tar.gz
     tar -xvzf zeromq.tar.gz
-    cmake -Hlibzmq-${ZMQ_VERSION} -Blibzmq ${ZEROMQ_CMAKE_FLAGS}
-    cmake --build libzmq
+    cmake -Hlibzmq-${ZMQ_VERSION} -B${LIBZMQ} -DWITH_PERF_TOOL=OFF \
+                                              -DZMQ_BUILD_TESTS=OFF \
+                                              -DCMAKE_BUILD_TYPE=Release \
+                                              ${ZEROMQ_CMAKE_FLAGS}
+    cmake --build ${LIBZMQ}
 }
 
 # build zeromq first
@@ -24,14 +29,14 @@ if [ "${ZMQ_VERSION}" != "" ] ; then install_zeromq ; fi
 
 # build cppzmq
 pushd .
-ZeroMQ_DIR=libzmq cmake -H. -Bbuild ${ZEROMQ_CMAKE_FLAGS}
-cmake --build build
-cd build
+ZeroMQ_DIR=${LIBZMQ} cmake -H. -B${CPPZMQ} ${ZEROMQ_CMAKE_FLAGS}
+cmake --build ${CPPZMQ}
+cd ${CPPZMQ}
 ctest -V
 popd
 
 # build cppzmq demo
-ZeroMQ_DIR=libzmq cppzmq_DIR=build cmake -Hdemo -Bdemo/build
+ZeroMQ_DIR=${LIBZMQ} cppzmq_DIR=${CPPZMQ} cmake -Hdemo -Bdemo/build
 cmake --build demo/build
 cd demo/build
 ctest

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -15,7 +15,8 @@ target_link_libraries(
     cppzmq
     )
 
-include_directories(${ZeroMQ_INCLUDE_DIR} ${cppzmq_INCLUDE_DIR})
+target_include_directories(demo PRIVATE ${cppzmq_INCLUDE_DIR}
+                                        ${ZeroMQ_INCLUDE_DIR})
 
 add_test(
   NAME

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(cppzmq-demo CXX)
 
-find_package(cppzmq REQUIRED)
+find_package(cppzmq)
 
 enable_testing()
 add_executable(
@@ -14,9 +14,6 @@ target_link_libraries(
     demo
     cppzmq
     )
-
-target_include_directories(demo PRIVATE ${cppzmq_INCLUDE_DIR}
-                                        ${ZeroMQ_INCLUDE_DIR})
 
 add_test(
   NAME

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(cppzmq-demo CXX)
 
-find_package(cppzmq)
+find_package(cppzmq REQUIRED)
 
 enable_testing()
 add_executable(
@@ -12,8 +12,10 @@ add_executable(
 
 target_link_libraries(
     demo
-    libzmq
+    cppzmq
     )
+
+include_directories(${ZeroMQ_INCLUDE_DIR} ${cppzmq_INCLUDE_DIR})
 
 add_test(
   NAME

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,9 +36,6 @@ target_link_libraries(
     cppzmq
     )
 
-target_include_directories(unit_tests PRIVATE ${cppzmq_INCLUDE_DIR}
-                                              ${ZeroMQ_INCLUDE_DIR})
-
 add_test(
   NAME
     unit

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,10 +33,11 @@ add_executable(
 target_link_libraries(
     unit_tests
     gtest_main
-    libzmq
+    cppzmq
     )
 
-target_include_directories(unit_tests PRIVATE ..)
+target_include_directories(unit_tests PRIVATE ${cppzmq_INCLUDE_DIR}
+                                              ${ZeroMQ_INCLUDE_DIR})
 
 add_test(
   NAME


### PR DESCRIPTION
Solution: Enable OSX build for xcode9.1 and clang on Travis.

Besides some more Travis build improvements. Please refer to commits descriptions for more details.