### PR TITLE
Problem: libzmq pkg-config build not covered by CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ matrix:
     # GCC on Linux
     ##########################################################
 
-    # GCC default, draft disabled, latest libzmq
-    - os: linux
-      env: ZMQ_VERSION=4.2.5
-
-    # GCC default, draft disabled,  older libzmq, libzmq with pkg-config
+    # GCC default, draft disabled,  older libzmq with pkg-config
     - os: linux
       sudo: true
       env: ZMQ_VERSION=4.2.0 BUILD_TYPE=pkgconf
+
+    # GCC default, draft disabled, latest libzmq
+    - os: linux
+      env: ZMQ_VERSION=4.2.5
 
     # GCC 7, draft enabled, latest libzmq
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - os: osx
       osx_image: xcode9.1
       compiler: clang
-      env: ZMQ_VERSION=4.2.5 DRAFT=1
+      env: DRAFT=1
 
     ##########################################################
     # GCC on Linux
@@ -27,11 +27,10 @@ matrix:
       sudo: true
       env: ZMQ_VERSION=4.2.0 BUILD_TYPE=pkgconfig
 
-    # GCC default, draft disabled, latest libzmq
+    # GCC default, draft disabled, default libzmq (defined in ci_build.sh)
     - os: linux
-      env: ZMQ_VERSION=4.2.5
 
-    # GCC 7, draft enabled, latest libzmq
+    # GCC 7, draft enabled (default), latest libzmq (default)
     - os: linux
       addons:
         apt:
@@ -40,7 +39,7 @@ matrix:
           packages:
             - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ZMQ_VERSION=4.2.5 DRAFT=1
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" DRAFT=1
   # - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=/usr/local/clang-5.0.0/bin/clang-format
     # os: linux
     # addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,10 @@ matrix:
     - os: linux
       env: ZMQ_VERSION=4.2.5
 
-    # GCC default, draft disabled,  older libzmq
+    # GCC default, draft disabled,  older libzmq, libzmq with pkg-config
     - os: linux
-      env: ZMQ_VERSION=4.2.4
+      sudo: true
+      env: ZMQ_VERSION=4.2.0 BUILD_TYPE=pkgconf
 
     # GCC 7, draft enabled, latest libzmq
     - os: linux
@@ -48,8 +49,6 @@ matrix:
         # - llvm-toolchain-trusty-5.0
       # packages:
         # - clang-5.0
-
-sudo: false
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install --user cpp-coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     # GCC default, draft disabled,  older libzmq with pkg-config
     - os: linux
       sudo: true
-      env: ZMQ_VERSION=4.2.0 BUILD_TYPE=pkgconf
+      env: ZMQ_VERSION=4.2.0 BUILD_TYPE=pkgconfig
 
     # GCC default, draft disabled, latest libzmq
     - os: linux

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -46,7 +46,9 @@ pushd .
 ZeroMQ_DIR=${LIBZMQ} cmake -H. -B${CPPZMQ} ${ZEROMQ_CMAKE_FLAGS}
 cmake --build ${CPPZMQ} -- -j${JOBS}
 if [ "$BUILD_TYPE" = "pkgconf" ] ; then
-    sudo cmake --build ${CPPZMQ} --target install
+    pushd .
+    cd ${CPPZMQ} && sudo make install
+    popd
 fi
 cd ${CPPZMQ}
 ctest -V -j${JOBS}

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -6,10 +6,12 @@ set -e
 BUILD_TYPE=${BUILD_TYPE:-cmake}
 LIBZMQ=${PWD}/libzmq-build
 CPPZMQ=${PWD}/cppzmq-build
+ZMQ_VERSION="4.2.5"
+DRAFT=${DRAFT:-0}
 # Travis machines have 2 cores
 JOBS=2
 
-if [ "$DRAFT" = "1" ] ; then
+if [ "${DRAFT}" = "1" ] ; then
     # if we enable drafts during the libzmq cmake build, the pkgconfig
     # data should set ZMQ_BUILD_DRAFT_API in dependent builds, but this
     # does not appear to work (TODO)
@@ -17,16 +19,16 @@ if [ "$DRAFT" = "1" ] ; then
 fi
 
 libzmq_install() {
-    curl -L https://github.com/zeromq/libzmq/archive/v${ZMQ_VERSION}.tar.gz \
+    curl -L https://github.com/zeromq/libzmq/archive/v"${ZMQ_VERSION}".tar.gz \
       >zeromq.tar.gz
     tar -xvzf zeromq.tar.gz
-    if [ "$BUILD_TYPE" = "cmake" ] ; then
+    if [ "${BUILD_TYPE}" = "cmake" ] ; then
         cmake -Hlibzmq-${ZMQ_VERSION} -B${LIBZMQ} -DWITH_PERF_TOOL=OFF \
                                                   -DZMQ_BUILD_TESTS=OFF \
                                                   -DCMAKE_BUILD_TYPE=Release \
                                                   ${ZEROMQ_CMAKE_FLAGS}
         cmake --build ${LIBZMQ} -- -j${JOBS}
-    elif [ "$BUILD_TYPE" = "pkgconfig" ] ; then
+    elif [ "${BUILD_TYPE}" = "pkgconfig" ] ; then
         pushd .
         cd libzmq-${ZMQ_VERSION}
         ./autogen.sh &&
@@ -41,12 +43,12 @@ libzmq_install() {
 # build zeromq first
 cppzmq_build() {
     pushd .
-    if [ "$BUILD_TYPE" = "cmake" ] ; then
+    if [ "${BUILD_TYPE}" = "cmake" ] ; then
         export ZeroMQ_DIR=${LIBZMQ}
     fi
     cmake -H. -B${CPPZMQ} ${ZEROMQ_CMAKE_FLAGS}
     cmake --build ${CPPZMQ} -- -j${JOBS}
-    if [ "$BUILD_TYPE" = "pkgconfig" ] ; then
+    if [ "${BUILD_TYPE}" = "pkgconfig" ] ; then
         cd ${CPPZMQ}
         sudo make install
     fi
@@ -62,7 +64,7 @@ cppzmq_tests() {
 
 cppzmq_demo() {
     pushd .
-    if [ "$BUILD_TYPE" = "cmake" ] ; then
+    if [ "${BUILD_TYPE}" = "cmake" ] ; then
         export ZeroMQ_DIR=${LIBZMQ}
         export cppzmq_DIR=${CPPZMQ}
     fi


### PR DESCRIPTION
Solution: libzmq pkg-config build (using autogen) added to Travis CI.

There is an issue with cppzmq where it needs to be installed as well in order to find pkg-config version of libzmq. That will be addressed in separate PR.