### PR TITLE
Problem: cppzmq needs to be installed for pkg-config libzmq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ install(FILES ${CPPZMQ_HEADERS}
 # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
 set(CPPZMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for cppzmqConfig.cmake")
 
+configure_file(libzmq-pkg-config/FindZeroMQ.cmake
+               libzmq-pkg-config/FindZeroMQ.cmake
+               COPYONLY)
+
 export(EXPORT ${PROJECT_NAME}-targets
      FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Supported platforms
 
  - Only a subset of the platforms that are supported by libzmq itself are supported. Some features already require a compiler supporting C++11. In the future, probably all features will require C++11. To build and run the tests, cmake and googletest are required.
  - Tested libzmq versions are
-   - 4.2.4 (without DRAFT API)
+   - 4.2.0 (without DRAFT API)
    - 4.2.5 (with and without DRAFT API)
  - Platforms with full support (i.e. CI executing build and tests)
    - Ubuntu 14.04 x64 (with gcc 4.8.4) (without DRAFT API only)

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -48,10 +48,6 @@ cppzmq_build() {
     fi
     cmake -H. -B${CPPZMQ} ${ZEROMQ_CMAKE_FLAGS}
     cmake --build ${CPPZMQ} -- -j${JOBS}
-    if [ "${BUILD_TYPE}" = "pkgconfig" ] ; then
-        cd ${CPPZMQ}
-        sudo make install
-    fi
     popd
 }
 
@@ -66,8 +62,8 @@ cppzmq_demo() {
     pushd .
     if [ "${BUILD_TYPE}" = "cmake" ] ; then
         export ZeroMQ_DIR=${LIBZMQ}
-        export cppzmq_DIR=${CPPZMQ}
     fi
+    cppzmq_DIR=${CPPZMQ} \
     cmake -Hdemo -Bdemo/build
     cmake --build demo/build
     cd demo/build


### PR DESCRIPTION
Solution: Make sure that FinZeroMQ.cmake is present in cppzmq's build
(binary) directory. That way cppzmq can be used from build/binary directory directly for all the cases.