### PR TITLE
Add message_t::routing_id() and set_routing_id()

### DIFF
--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -118,3 +118,12 @@ TEST(message, equality_non_equal_lhs_empty)
     const zmq::message_t msg_b("Hi", 2);
     ASSERT_NE(msg_a, msg_b);
 }
+
+#if defined(ZMQ_BUILD_DRAFT_API) && ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 0)
+TEST(message, routing_id_persists)
+{
+    zmq::message_t msg;
+    msg.set_routing_id(123);
+    ASSERT_EQ(123u, msg.routing_id());
+}
+#endif

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -396,6 +396,21 @@ class message_t
         return value;
     }
 #endif
+
+#if defined(ZMQ_BUILD_DRAFT_API) && ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 0)
+    inline uint32_t routing_id() const
+    {
+        return zmq_msg_routing_id(const_cast<zmq_msg_t*>(&msg));
+    }
+
+    inline void set_routing_id(uint32_t routing_id)
+    {
+        int rc = zmq_msg_set_routing_id(&msg, routing_id);
+        if (rc != 0)
+            throw error_t();
+    }
+#endif
+
     /** Dump content to string. Ascii chars are readable, the rest is printed as hex.
          *  Probably ridiculously slow.
          */


### PR DESCRIPTION
Setting a routing id is necessary when sending a message through a
ZMQ_SERVER socket. See [1] for more details.

This commit fixes #233.

[1] http://api.zeromq.org/4-2:zmq-socket#toc5