### PR TITLE
Problem: cmake build succeeds even if libzmq not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,14 @@ find_package(ZeroMQ QUIET)
 
 # libzmq autotools install: fallback to pkg-config
 if(NOT ZeroMQ_FOUND)
-    # try again with pkg-config (normal install of zeromq)
+    message(STATUS "CMake libzmq package not found, trying again with pkg-config (normal install of zeromq)")
     list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/libzmq-pkg-config)
     find_package(ZeroMQ REQUIRED)
+endif()
+
+# TODO "REQUIRED" above should already cause a fatal failure if not found, but this doesn't seem to work
+if(NOT ZeroMQ_FOUND)
+    message(FATAL_ERROR "ZeroMQ was not found, neither as a CMake package nor via pkg-config")
 endif()
 
 if (ZeroMQ_FOUND AND (NOT TARGET libzmq OR NOT TARGET libzmq-static))


### PR DESCRIPTION
Solution: raise a FATAL_ERROR if not found, and improve diagnostic output

Catches the error reported in #241 already during cmake run