### PR TITLE
Problem: coverate not supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,21 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ENABLE_DRAFTS=ON
+
+    # Coverage, GCC 7, draft enabled, latest libzmq (default)
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - lcov
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ENABLE_DRAFTS=ON COVERAGE=ON
+      after_success:
+        - cd cppzmq-build
+        - bash <(curl -s https://codecov.io/bash) -X fix
   # - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=/usr/local/clang-5.0.0/bin/clang-format
     # os: linux
     # addons:
@@ -60,14 +75,8 @@ matrix:
       # packages:
         # - clang-5.0
 
-before_install:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pip install --user cpp-coveralls; fi
-
 # Build and check this project
 script:
   - eval "${MATRIX_EVAL}"
   - cmake --version
   - ./ci_build.sh
-
-after_success:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then coveralls --root . -E ".*external.*" -E ".*CMakeFiles.*" -E ".*tests/" -E ".*demo/" -E ".*libzmq/"; fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Travis-CI Status](https://travis-ci.org/zeromq/cppzmq.svg?branch=master)](https://travis-ci.org/zeromq/cppzmq)
 [![Appveyor Status](https://ci.appveyor.com/api/projects/status/bvi5axi8um7goh50/branch/master?svg=true)](https://ci.appveyor.com/project/zeromq/cppzmq/branch/master)
-[![Coverage Status](https://coveralls.io/repos/github/zeromq/cppzmq/badge.svg?branch=master)](https://coveralls.io/github/zeromq/cppzmq?branch=master)
+[![Coverage Status](https://codecov.io/github/zeromq/cppzmq/coverage.svg?branch=master)](https://codecov.io/gh/github/zeromq/cppzmq/branch/master)
 
 Introduction & Design Goals
 ===========================


### PR DESCRIPTION
Solution: enable code coverage and report it to codecov.io
Note: This requires zeromq/cppzmq to be enabled on codecov.io