### PR TITLE
Problem: README build badges too generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,7 @@ cpp zmq (which will also include libzmq for you).
 ```
 #find cppzmq wrapper, installed by make of cppzmq
 find_package(cppzmq)
-if(cppzmq_FOUND)
-    include_directories(${ZeroMQ_INCLUDE_DIR} ${cppzmq_INCLUDE_DIR})
-    target_link_libraries(*Your Project Name* ${cppzmq_LIBRARY})
-endif()
+target_link_libraries(*Your Project Name* cppzmq)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Travis-CI Status](https://travis-ci.org/zeromq/cppzmq.svg?branch=master)](https://travis-ci.org/zeromq/cppzmq)
-[![Appveyor Status](https://ci.appveyor.com/api/projects/status/bvi5axi8um7goh50/branch/master?svg=true)](https://ci.appveyor.com/project/zeromq/cppzmq/branch/master)
+[![Travis-CI Status](https://img.shields.io/travis/zeromq/cppzmq/master.svg?label=Linux%20|%20OSX)](https://travis-ci.org/zeromq/cppzmq)
+[![Appveyor Status](https://img.shields.io/appveyor/ci/zeromq/cppzmq/master.svg?label=Windows)](https://ci.appveyor.com/project/zeromq/cppzmq/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/zeromq/cppzmq/badge.svg?branch=master)](https://coveralls.io/github/zeromq/cppzmq?branch=master)
+[![License](https://img.shields.io/github/license/zeromq/cppzmq.svg)](https://github.com/zeromq/cppzmq/blob/master/LICENSE)
 
 Introduction & Design Goals
 ===========================


### PR DESCRIPTION
Solution: Show Linux, OSX and Windows labels on build badges for more
visibility on supported platforms.

Additionally added license badge.