### PR TITLE
editing "typename I" to "typename T" due to error: expected nested-na…

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -230,10 +230,10 @@ class message_t
             throw error_t();
     }
 
-    template<typename I> message_t(I first, I last) : msg()
+    template<typename T> message_t(T first, T last) : msg()
     {
-        typedef typename std::iterator_traits<I>::difference_type size_type;
-        typedef typename std::iterator_traits<I>::value_type value_t;
+        typedef typename std::iterator_traits<T>::difference_type size_type;
+        typedef typename std::iterator_traits<T>::value_type value_t;
 
         size_type const size_ = std::distance(first, last) * sizeof(value_t);
         int const rc = zmq_msg_init_size(&msg, size_);
@@ -685,7 +685,7 @@ class socket_t
         throw error_t();
     }
 
-    template<typename I> bool send(I first, I last, int flags_ = 0)
+    template<typename T> bool send(T first, T last, int flags_ = 0)
     {
         zmq::message_t msg(first, last);
         return send(msg, flags_);


### PR DESCRIPTION
…me-specifier before ‘(’ token

on c++ (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609

Full error:
```bash
In file included from /usr/include/c++/5/complex.h:36:0,
                 from /home/x/modem_main.cpp:5:
/usr/local/include/zmq.hpp:221:27: error: expected nested-name-specifier before ‘(’ token
         template<typename I> message_t(I first, I last):
                           ^
/usr/local/include/zmq.hpp:221:27: error: expected ‘)’ before ‘__extension__’
         template<typename I> message_t(I first, I last):
                           ^
/usr/local/include/zmq.hpp:221:27: error: expected ‘>’ before ‘__extension__’
/usr/local/include/zmq.hpp:221:27: error: expected unqualified-id before ‘)’ token
         template<typename I> message_t(I first, I last):
                           ^
/usr/local/include/zmq.hpp:644:27: error: expected nested-name-specifier before ‘(’ token
         template<typename I> bool send(I first, I last, int flags_=0)
                           ^
/usr/local/include/zmq.hpp:644:27: error: expected ‘)’ before ‘__extension__’
         template<typename I> bool send(I first, I last, int flags_=0)
                           ^
/usr/local/include/zmq.hpp:644:27: error: expected ‘>’ before ‘__extension__’
/usr/local/include/zmq.hpp:644:27: error: expected unqualified-id before ‘)’ token
         template<typename I> bool send(I first, I last, int flags_=0)
                           ^
/usr/local/include/zmq.hpp:644:27: error: expected nested-name-specifier before ‘(’ token
         template<typename I> bool send(I first, I last, int flags_=0)
                           ^
/usr/local/include/zmq.hpp:644:27: error: expected ‘)’ before ‘__extension__’
         template<typename I> bool send(I first, I last, int flags_=0)
                           ^
/usr/local/include/zmq.hpp:644:27: error: expected ‘>’ before ‘__extension__’
/usr/local/include/zmq.hpp:644:27: error: expected unqualified-id before ‘)’ token
         template<typename I> bool send(I first, I last, int flags_=0)
```

I am compiling with cmake but the compile flags seems to be:
```bash
/usr/bin/c++   -I/home/x/inc -I/usr/local/include  -fvisibility-inlines-hidden -Wno-unused-parameter -Wno-return-type -O3 -DNDEBUG   -Wall -Wextra -fvisibility=hidden -std=gnu++14 -o CMakeFiles/zmq_test_1.dir/src/test_zmq.cpp.o -c /home/x/test_zmq.cpp
```
