### PR TITLE
Problem: #209 and monitor_t tests not event driven

### DIFF
--- a/cppzmqConfig.cmake.in
+++ b/cppzmqConfig.cmake.in
@@ -30,9 +30,7 @@ if(NOT ZeroMQ_FOUND)
 endif()
 
 if(NOT TARGET @PROJECT_NAME@)
-  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
-
-  get_target_property(@PROJECT_NAME@_INCLUDE_DIR cppzmq INTERFACE_INCLUDE_DIRECTORIES)
-  get_target_property(@PROJECT_NAME@_LIBRARY libzmq LOCATION)
-  get_target_property(@PROJECT_NAME@_STATIC_LIBRARY libzmq-static LOCATION)
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+    get_target_property(@PROJECT_NAME@_INCLUDE_DIR cppzmq INTERFACE_INCLUDE_DIRECTORIES)
 endif()
+

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 #include <zmq.hpp>
 
-#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)
+#if defined(ZMQ_CPP11)
 #include <array>
 
 class loopback_ip4_binder
@@ -31,7 +31,11 @@ class loopback_ip4_binder
 
 struct common_server_client_setup
 {
-    common_server_client_setup() { init(); }
+    common_server_client_setup(bool initialize = true)
+    {
+        if (initialize)
+            init();
+    }
 
     void init()
     {
@@ -40,8 +44,8 @@ struct common_server_client_setup
     }
 
     zmq::context_t context;
-    zmq::socket_t server{context, zmq::socket_type::server};
-    zmq::socket_t client{context, zmq::socket_type::client};
+    zmq::socket_t server{context, zmq::socket_type::pair};
+    zmq::socket_t client{context, zmq::socket_type::pair};
     std::string endpoint;
 };
 #endif


### PR DESCRIPTION
Problem: #209 cppzmq fails with cmake 3.6.3 and above
Solution: remove problematic cmake lines as they seem to be not necessary.

Problem: monitor_t tests not event driven 
Solution: instead of waiting for fixed amount of time for events, react
as soon as events are triggered.
- Total running time of unittest reduced 10x (from ~300ms to 30ms).
- Reduced code duplication by reusing testutil's constructs.