### PR TITLE
Problem: addition of new single-argument message_t introduces ambigui…

### DIFF
--- a/tests/active_poller.cpp
+++ b/tests/active_poller.cpp
@@ -157,7 +157,7 @@ TEST(active_poller, poll_basic)
 {
     server_client_setup s;
 
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
 
     zmq::active_poller_t active_poller;
     bool message_received = false;
@@ -196,7 +196,7 @@ TEST(active_poller, client_server)
     ASSERT_NO_THROW(active_poller.add(s.server, ZMQ_POLLIN, handler));
 
     // client sends message
-    ASSERT_NO_THROW(s.client.send(send_msg));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{send_msg}));
 
     ASSERT_EQ(1, active_poller.wait(std::chrono::milliseconds{-1}));
     ASSERT_EQ(events, ZMQ_POLLIN);
@@ -235,7 +235,7 @@ TEST(active_poller, remove_invalid_socket_throws)
 TEST(active_poller, wait_on_added_empty_handler)
 {
     server_client_setup s;
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
     zmq::active_poller_t active_poller;
     zmq::active_poller_t::handler_t handler;
     ASSERT_NO_THROW(active_poller.add(s.server, ZMQ_POLLIN, handler));
@@ -290,7 +290,7 @@ TEST(active_poller, poll_client_server)
     ASSERT_NO_THROW(active_poller.add(s.server, ZMQ_POLLIN, s.handler));
 
     // client sends message
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
 
     // wait for message and verify events
     ASSERT_NO_THROW(active_poller.wait(std::chrono::milliseconds{500}));
@@ -315,7 +315,7 @@ TEST(active_poller, wait_one_return)
       active_poller.add(s.server, ZMQ_POLLIN, [&count](short) { ++count; }));
 
     // client sends message
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
 
     // wait for message and verify events
     ASSERT_EQ(1, active_poller.wait(std::chrono::milliseconds{500}));
@@ -325,7 +325,7 @@ TEST(active_poller, wait_one_return)
 TEST(active_poller, wait_on_move_constructed_active_poller)
 {
     server_client_setup s;
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
     zmq::active_poller_t a;
     zmq::active_poller_t::handler_t handler;
     ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, handler));
@@ -339,7 +339,7 @@ TEST(active_poller, wait_on_move_constructed_active_poller)
 TEST(active_poller, wait_on_move_assigned_active_poller)
 {
     server_client_setup s;
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
     zmq::active_poller_t a;
     zmq::active_poller_t::handler_t handler;
     ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, handler));
@@ -360,14 +360,14 @@ TEST(active_poller, received_on_move_constructed_active_poller)
     zmq::active_poller_t a;
     ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, [&count](short) { ++count; }));
     // client sends message
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
     // wait for message and verify it is received
     ASSERT_EQ(1, a.wait(std::chrono::milliseconds{500}));
     ASSERT_EQ(1u, count);
     // Move construct active_poller b
     zmq::active_poller_t b{std::move(a)};
     // client sends message again
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
     // wait for message and verify it is received
     ASSERT_EQ(1, b.wait(std::chrono::milliseconds{500}));
     ASSERT_EQ(2u, count);
@@ -398,7 +398,7 @@ TEST(active_poller, remove_from_handler)
     ASSERT_EQ(ITER_NO, active_poller.size());
     // Clients send messages
     for (auto &s : setup_list) {
-        ASSERT_NO_THROW(s.client.send("Hi"));
+        ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
     }
 
     // Wait for all servers to receive a message

--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -128,7 +128,7 @@ TEST(poller, poll_basic)
 {
     common_server_client_setup s;
 
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
 
     zmq::poller_t<int> poller;
     std::vector<zmq_poller_event_t> events{1};
@@ -206,7 +206,7 @@ TEST(poller, poll_client_server)
     ASSERT_NO_THROW(poller.add(s.server, ZMQ_POLLIN, s.server));
 
     // client sends message
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
 
     // wait for message and verify events
     std::vector<zmq_poller_event_t> events(1);
@@ -229,7 +229,7 @@ TEST(poller, wait_one_return)
     ASSERT_NO_THROW(poller.add(s.server, ZMQ_POLLIN, nullptr));
 
     // client sends message
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
 
     // wait for message and verify events
     std::vector<zmq_poller_event_t> events(1);
@@ -239,7 +239,7 @@ TEST(poller, wait_one_return)
 TEST(poller, wait_on_move_constructed_poller)
 {
     common_server_client_setup s;
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
     zmq::poller_t<> a;
     ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, nullptr));
     zmq::poller_t<> b{std::move(a)};
@@ -252,7 +252,7 @@ TEST(poller, wait_on_move_constructed_poller)
 TEST(poller, wait_on_move_assigned_poller)
 {
     common_server_client_setup s;
-    ASSERT_NO_THROW(s.client.send("Hi"));
+    ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
     zmq::poller_t<> a;
     ASSERT_NO_THROW(a.add(s.server, ZMQ_POLLIN, nullptr));
     zmq::poller_t<> b;
@@ -279,7 +279,7 @@ TEST(poller, remove_from_handler)
     }
     // Clients send messages
     for (auto &s : setup_list) {
-        ASSERT_NO_THROW(s.client.send("Hi"));
+        ASSERT_NO_THROW(s.client.send(zmq::message_t{"Hi"}));
     }
 
     // Wait for all servers to receive a message

--- a/tests/socket.cpp
+++ b/tests/socket.cpp
@@ -14,3 +14,16 @@ TEST(socket, create_by_enum_destroy)
     zmq::socket_t socket(context, zmq::socket_type::router);
 }
 #endif
+
+TEST(socket, send_receive_const_buffer)
+{
+    zmq::context_t context;
+    zmq::socket_t sender(context, ZMQ_PAIR);
+    zmq::socket_t receiver(context, ZMQ_PAIR);
+    receiver.bind("inproc://test");
+    sender.connect("inproc://test");
+    ASSERT_EQ(2, sender.send("Hi", 2));
+    char buf[2];
+    ASSERT_EQ(2, receiver.recv(buf, 2));
+    ASSERT_EQ(0, memcmp(buf, "Hi", 2));
+}

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -264,7 +264,7 @@ class message_t
 
 #if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)
     template<typename T>
-    message_t(const T &msg_) : message_t(std::begin(msg_), std::end(msg_))
+    explicit message_t(const T &msg_) : message_t(std::begin(msg_), std::end(msg_))
     {
     }
 #endif

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -63,8 +63,8 @@
 
 /*  Version macros for compile-time API version detection                     */
 #define CPPZMQ_VERSION_MAJOR 4
-#define CPPZMQ_VERSION_MINOR 4 
-#define CPPZMQ_VERSION_PATCH 0
+#define CPPZMQ_VERSION_MINOR 3 
+#define CPPZMQ_VERSION_PATCH 1 
 
 #define CPPZMQ_VERSION                                                              \
     ZMQ_MAKE_VERSION(CPPZMQ_VERSION_MAJOR, CPPZMQ_VERSION_MINOR,                    \


### PR DESCRIPTION
…ty when calling e.g. socket_t::send

Solution: make single-argument constructor explicit