### PR TITLE
add front and back

### DIFF
--- a/tests/multipart.cpp
+++ b/tests/multipart.cpp
@@ -74,6 +74,14 @@ TEST(multipart, legacy_test)
     multipart.pushtyp(1.0f);
     multipart.pushmem("Frame0", 6);
     assert(multipart.size() == 10);
+    
+    const message_t& front_msg = multipart.front();
+    assert(multipart.size() == 10);
+    assert(std::string(front_msg.data<char>(), front_msg.size()) == "Frame0");
+    
+    const message_t& back_msg = multipart.back();
+    assert(multipart.size() == 10);
+    assert(std::string(back_msg.data<char>(), back_msg.size()) == "Frame9");
 
     msg = multipart.remove();
     assert(multipart.size() == 9);

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -245,6 +245,18 @@ class multipart_t
         m_parts.pop_back();
         return message;
     }
+    
+    // get message part from front
+    const message_t &front()
+    {
+        return m_parts.front();
+    }
+
+    // get message part from back
+    const message_t &back()
+    {
+        return m_parts.back();
+    }
 
     // Get pointer to a specific message part
     const message_t *peek(size_t index) const { return &m_parts[index]; }


### PR DESCRIPTION
i'll get the last message in some situations，but have to do like this :
```
multimsg msgs;
auto msg = msgs[msgs.size() - 1];
func(msg.size());
auto *msg = msgs.end() - 1;
```
but, std::queue have some method 'front' and 'back'. so maybe i can simply do this ？ :
```
multimsg msgs;
auto msg = msgs.back();
```