### PR TITLE
Problem #268: CTest output without tests details

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,10 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
 
+include(CTest)
 include(cmake/catch.cmake)
+include(${CATCH_MODULE_PATH}/Catch.cmake)
+
 find_package(Threads)
 
 add_executable(
@@ -25,7 +28,7 @@ add_executable(
 
 add_dependencies(unit_tests catch)
 
-target_include_directories(unit_tests PUBLIC ${CATCH_INCLUDE_DIR})
+target_include_directories(unit_tests PUBLIC ${CATCH_MODULE_PATH})
 target_link_libraries(
     unit_tests
     PRIVATE cppzmq
@@ -39,9 +42,4 @@ if (COVERAGE)
     target_link_libraries(unit_tests PRIVATE --coverage)
 endif()
 
-add_test(
-  NAME
-    unit
-  COMMAND
-    ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/unit_tests
-)
+catch_discover_tests(unit_tests)

--- a/tests/cmake/catch.cmake
+++ b/tests/cmake/catch.cmake
@@ -11,6 +11,17 @@ ExternalProject_Add(
   DOWNLOAD_NO_EXTRACT ON
 )
 
-# Expose variable CATCH_INCLUDE_DIR to parent scope
+# Expose variable CATCH_MODULE_PATH to parent scope
 ExternalProject_Get_Property(catch DOWNLOAD_DIR)
-set(CATCH_INCLUDE_DIR ${DOWNLOAD_DIR} CACHE INTERNAL "Path to include catch")
+set(CATCH_MODULE_PATH ${DOWNLOAD_DIR} CACHE INTERNAL "Path to include catch")
+
+# Download module for CTest integration
+if(NOT EXISTS "${CATCH_MODULE_PATH}/Catch.cmake")
+    file(DOWNLOAD "https://raw.githubusercontent.com/catchorg/Catch2/master/contrib/Catch.cmake"
+        "${CATCH_MODULE_PATH}/Catch.cmake")
+endif()
+if(NOT EXISTS "${CATCH_MODULE_PATH}/CatchAddTests.cmake")
+    file(DOWNLOAD "https://raw.githubusercontent.com/catchorg/Catch2/master/contrib/CatchAddTests.cmake"
+        "${CATCH_MODULE_PATH}/CatchAddTests.cmake")
+endif()
+


### PR DESCRIPTION
Solution: Added integration with CTest to existing unit test framework
based on Catch. ctest -v returns list of run tests now.

Changes:

* downloading and using Catch cmake modules that `unit_tests
--list-test-names-only` for add_test internally