### PR TITLE
Problem: catch must be downloaded during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     # GCC on Linux
     ##########################################################
 
-    # Coverage, GCC 7, draft enabled, latest libzmq (default)
+    # Coverage, GCC 7, draft enabled, latest libzmq (default), external Catch2
     - os: linux
       before_install:
         - pip install --user cpp-coveralls
@@ -34,18 +34,18 @@ matrix:
           packages:
             - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ENABLE_DRAFTS=ON COVERAGE=ON
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" ENABLE_DRAFTS=ON COVERAGE=ON CATCH2_VERSION=2.5.0
       after_success:
         - coveralls -r . -E ".*external.*" -E ".*CMakeFiles.*" -E ".*tests/" -E ".*demo/" -E ".*libzmq.*/" -b cppzmq-build --gcov-options '\-lp'
 
-    # GCC default, draft disabled,  older libzmq with pkg-config
+    # GCC default, draft disabled,  older libzmq with pkg-config, internal Catch
     - os: linux
       env: ZMQ_VERSION=4.2.0 BUILD_TYPE=pkgconfig
 
-    # GCC default, draft disabled, default libzmq (defined in ci_build.sh)
+    # GCC default, draft disabled, default libzmq (defined in ci_build.sh), internal Catch
     - os: linux
 
-    # GCC 6, draft disabled (default), latest libzmq (default)
+    # GCC 6, draft disabled (default), latest libzmq (default), external Catch1
     - os: linux
       addons:
         apt:
@@ -53,10 +53,11 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-6
+            - catch
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
-    # GCC 7, draft enabled, latest libzmq (default)
+    # GCC 7, draft enabled, latest libzmq (default), internal Catch
     - os: linux
       addons:
         apt:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,10 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
 
+include(CTest)
 include(cmake/catch.cmake)
+include(${CATCH_MODULE_PATH}/Catch.cmake)
+
 find_package(Threads)
 
 add_executable(
@@ -25,7 +28,7 @@ add_executable(
 
 add_dependencies(unit_tests catch)
 
-target_include_directories(unit_tests PUBLIC ${CATCH_INCLUDE_DIR})
+target_include_directories(unit_tests PUBLIC ${CATCH_MODULE_PATH})
 target_link_libraries(
     unit_tests
     PRIVATE cppzmq
@@ -39,9 +42,4 @@ if (COVERAGE)
     target_link_libraries(unit_tests PRIVATE --coverage)
 endif()
 
-add_test(
-  NAME
-    unit
-  COMMAND
-    ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/unit_tests
-)
+catch_discover_tests(unit_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,8 +10,23 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
 
 include(CTest)
-include(cmake/catch.cmake)
-include(${CATCH_MODULE_PATH}/Catch.cmake)
+find_package(Catch2 QUIET)
+if (Catch2_FOUND)
+    message(STATUS "Using external Catch 2: ${Catch2_VERSION}")
+    set(CATCH_TYPE "catch2")
+    include(Catch)
+else()
+    find_path(CATCH_HEADER_DIR "catch.hpp")
+    if (CATCH_HEADER_DIR)
+        message(STATUS "Using external Catch 1 at ${CATCH_HEADER_DIR}")
+        set(CATCH_TYPE "catch1")
+    else()
+        message(STATUS "Using downloaded copy of Catch.")
+        include(cmake/catch.cmake)
+        include(${CATCH_MODULE_PATH}/Catch.cmake)
+        set(CATCH_TYPE "internal")
+    endif()
+endif()
 
 find_package(Threads)
 
@@ -26,9 +41,16 @@ add_executable(
 	monitor.cpp
 )
 
-add_dependencies(unit_tests catch)
+if (CATCH_TYPE STREQUAL "catch2")
+    target_link_libraries(unit_tests PRIVATE Catch2::Catch2)
+    target_compile_definitions(unit_tests PRIVATE -DUSE_EXTERNAL_CATCH2)
+elseif(CATCH_TYPE STREQUAL "catch1")
+    target_include_directories(unit_tests PRIVATE ${CATCH_HEADER_DIR})
+else()
+    add_dependencies(unit_tests catch)
+    target_include_directories(unit_tests PUBLIC ${CATCH_MODULE_PATH})
+endif()
 
-target_include_directories(unit_tests PUBLIC ${CATCH_MODULE_PATH})
 target_link_libraries(
     unit_tests
     PRIVATE cppzmq
@@ -42,4 +64,13 @@ if (COVERAGE)
     target_link_libraries(unit_tests PRIVATE --coverage)
 endif()
 
-catch_discover_tests(unit_tests)
+if (CATCH_TYPE STREQUAL "catch1")
+    add_test(
+      NAME
+        unit
+      COMMAND
+        ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/unit_tests
+    )
+else()
+    catch_discover_tests(unit_tests)
+endif()

--- a/tests/cmake/catch.cmake
+++ b/tests/cmake/catch.cmake
@@ -11,6 +11,17 @@ ExternalProject_Add(
   DOWNLOAD_NO_EXTRACT ON
 )
 
-# Expose variable CATCH_INCLUDE_DIR to parent scope
+# Expose variable CATCH_MODULE_PATH to parent scope
 ExternalProject_Get_Property(catch DOWNLOAD_DIR)
-set(CATCH_INCLUDE_DIR ${DOWNLOAD_DIR} CACHE INTERNAL "Path to include catch")
+set(CATCH_MODULE_PATH ${DOWNLOAD_DIR} CACHE INTERNAL "Path to include catch")
+
+# Download module for CTest integration
+if(NOT EXISTS "${CATCH_MODULE_PATH}/Catch.cmake")
+    file(DOWNLOAD "https://raw.githubusercontent.com/catchorg/Catch2/master/contrib/Catch.cmake"
+        "${CATCH_MODULE_PATH}/Catch.cmake")
+endif()
+if(NOT EXISTS "${CATCH_MODULE_PATH}/CatchAddTests.cmake")
+    file(DOWNLOAD "https://raw.githubusercontent.com/catchorg/Catch2/master/contrib/CatchAddTests.cmake"
+        "${CATCH_MODULE_PATH}/CatchAddTests.cmake")
+endif()
+

--- a/tests/context.cpp
+++ b/tests/context.cpp
@@ -1,4 +1,8 @@
+#ifdef USE_EXTERNAL_CATCH2
+#include <catch2/catch.hpp>
+#else
 #include <catch.hpp>
+#endif
 #include <zmq.hpp>
 
 TEST_CASE("context construct default and destroy", "[context]")

--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -1,5 +1,9 @@
 #define CATCH_CONFIG_MAIN
+#ifdef USE_EXTERNAL_CATCH2
+#include <catch2/catch.hpp>
+#else
 #include <catch.hpp>
+#endif
 #include <zmq.hpp>
 
 #if defined(ZMQ_CPP11)

--- a/tests/multipart.cpp
+++ b/tests/multipart.cpp
@@ -1,4 +1,8 @@
+#ifdef USE_EXTERNAL_CATCH2
+#include <catch2/catch.hpp>
+#else
 #include <catch.hpp>
+#endif
 #include <zmq_addon.hpp>
 
 #ifdef ZMQ_HAS_RVALUE_REFS

--- a/tests/socket.cpp
+++ b/tests/socket.cpp
@@ -1,4 +1,8 @@
+#ifdef USE_EXTERNAL_CATCH2
+#include <catch2/catch.hpp>
+#else
 #include <catch.hpp>
+#endif
 #include <zmq.hpp>
 
 TEST_CASE("socket create destroy", "[socket]")

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
+#ifdef USE_EXTERNAL_CATCH2
+#include <catch2/catch.hpp>
+#else
 #include <catch.hpp>
+#endif
 #include <zmq.hpp>
 
 #if defined(ZMQ_CPP11)


### PR DESCRIPTION
This is trouble for building packages as there is no network, and we want everything to be available from sources we've already built.

The solution here is to allow building against an external (packaged) Catch. I added support for both Catch2 and Catch, and testing in TravisCI.

This is based on #286 due to eventual conflicts.