### PR TITLE
Removed warnings when compiling with C++11 enabled

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -42,7 +42,7 @@
 #define ZMQ_NULLPTR nullptr
 #else
 #define ZMQ_CPP03
-#define ZMQ_NOTHROW
+#define ZMQ_NOTHROW throw()
 #define ZMQ_EXPLICIT
 #define ZMQ_OVERRIDE
 #define ZMQ_NULLPTR 0

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -39,11 +39,13 @@
 #define ZMQ_NOTHROW noexcept
 #define ZMQ_EXPLICIT explicit
 #define ZMQ_OVERRIDE override
+#define ZMQ_NULLPTR nullptr
 #else
 #define ZMQ_CPP03
 #define ZMQ_NOTHROW
 #define ZMQ_EXPLICIT
 #define ZMQ_OVERRIDE
+#define ZMQ_NULLPTR 0
 #endif
 
 #include <zmq.h>
@@ -61,8 +63,8 @@
 
 /*  Version macros for compile-time API version detection                     */
 #define CPPZMQ_VERSION_MAJOR 4
-#define CPPZMQ_VERSION_MINOR 3 
-#define CPPZMQ_VERSION_PATCH 1 
+#define CPPZMQ_VERSION_MINOR 3
+#define CPPZMQ_VERSION_PATCH 1
 
 #define CPPZMQ_VERSION                                                              \
     ZMQ_MAKE_VERSION(CPPZMQ_VERSION_MAJOR, CPPZMQ_VERSION_MINOR,                    \
@@ -138,11 +140,7 @@ class error_t : public std::exception
 {
   public:
     error_t() : errnum(zmq_errno()) {}
-#ifdef ZMQ_CPP11
-    virtual const char *what() const noexcept { return zmq_strerror(errnum); }
-#else
-    virtual const char *what() const throw() { return zmq_strerror(errnum); }
-#endif
+    virtual const char *what() const ZMQ_NOTHROW ZMQ_OVERRIDE { return zmq_strerror(errnum); }
     int num() const { return errnum; }
 
   private:
@@ -253,7 +251,7 @@ class message_t
         memcpy(data(), data_, size_);
     }
 
-    inline message_t(void *data_, size_t size_, free_fn *ffn_, void *hint_ = NULL)
+    inline message_t(void *data_, size_t size_, free_fn *ffn_, void *hint_ = ZMQ_NULLPTR)
     {
         int rc = zmq_msg_init_data(&msg, data_, size_, ffn_, hint_);
         if (rc != 0)
@@ -319,7 +317,7 @@ class message_t
         memcpy(data(), data_, size_);
     }
 
-    inline void rebuild(void *data_, size_t size_, free_fn *ffn_, void *hint_ = NULL)
+    inline void rebuild(void *data_, size_t size_, free_fn *ffn_, void *hint_ = ZMQ_NULLPTR)
     {
         int rc = zmq_msg_close(&msg);
         if (rc != 0)
@@ -389,7 +387,7 @@ class message_t
     inline const char *gets(const char *property_)
     {
         const char *value = zmq_msg_gets(&msg, property_);
-        if (value == NULL)
+        if (value == ZMQ_NULLPTR)
             throw error_t();
         return value;
     }
@@ -478,7 +476,7 @@ class context_t
     inline context_t()
     {
         ptr = zmq_ctx_new();
-        if (ptr == NULL)
+        if (ptr == ZMQ_NULLPTR)
             throw error_t();
     }
 
@@ -487,7 +485,7 @@ class context_t
                               int max_sockets_ = ZMQ_MAX_SOCKETS_DFLT)
     {
         ptr = zmq_ctx_new();
-        if (ptr == NULL)
+        if (ptr == ZMQ_NULLPTR)
             throw error_t();
 
         int rc = zmq_ctx_set(ptr, ZMQ_IO_THREADS, io_threads_);
@@ -498,7 +496,7 @@ class context_t
     }
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    inline context_t(context_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr) { rhs.ptr = NULL; }
+    inline context_t(context_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr) { rhs.ptr = ZMQ_NULLPTR; }
     inline context_t &operator=(context_t &&rhs) ZMQ_NOTHROW
     {
         std::swap(ptr, rhs.ptr);
@@ -519,7 +517,7 @@ class context_t
 
     inline void close() ZMQ_NOTHROW
     {
-        if (ptr == NULL)
+        if (ptr == ZMQ_NULLPTR)
             return;
 
         int rc;
@@ -528,7 +526,7 @@ class context_t
         } while (rc == -1 && errno == EINTR);
 
         ZMQ_ASSERT(rc == 0);
-        ptr = NULL;
+        ptr = ZMQ_NULLPTR;
     }
 
     //  Be careful with this, it's probably only useful for
@@ -538,7 +536,7 @@ class context_t
 
     inline ZMQ_EXPLICIT operator void const *() const ZMQ_NOTHROW { return ptr; }
 
-    inline operator bool() const ZMQ_NOTHROW { return ptr != NULL; }
+    inline operator bool() const ZMQ_NOTHROW { return ptr != ZMQ_NULLPTR; }
 
   private:
     void *ptr;
@@ -590,8 +588,8 @@ class socket_t
 #ifdef ZMQ_HAS_RVALUE_REFS
     inline socket_t(socket_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr), ctxptr(rhs.ctxptr)
     {
-        rhs.ptr = NULL;
-        rhs.ctxptr = NULL;
+        rhs.ptr = ZMQ_NULLPTR;
+        rhs.ctxptr = ZMQ_NULLPTR;
     }
     inline socket_t &operator=(socket_t &&rhs) ZMQ_NOTHROW
     {
@@ -608,12 +606,12 @@ class socket_t
 
     inline void close() ZMQ_NOTHROW
     {
-        if (ptr == NULL)
+        if (ptr == ZMQ_NULLPTR)
             // already closed
             return;
         int rc = zmq_close(ptr);
         ZMQ_ASSERT(rc == 0);
-        ptr = 0;
+        ptr = ZMQ_NULLPTR;
     }
 
     template<typename T> void setsockopt(int option_, T const &optval)
@@ -679,7 +677,7 @@ class socket_t
             throw error_t();
     }
 
-    inline bool connected() const ZMQ_NOTHROW { return (ptr != NULL); }
+    inline bool connected() const ZMQ_NOTHROW { return (ptr != ZMQ_NULLPTR); }
 
     inline size_t send(const void *buf_, size_t len_, int flags_ = 0)
     {
@@ -752,7 +750,7 @@ class socket_t
     {
         ctxptr = context_.ptr;
         ptr = zmq_socket(context_.ptr, type_);
-        if (ptr == NULL)
+        if (ptr == ZMQ_NULLPTR)
             throw error_t();
     }
 
@@ -766,12 +764,12 @@ class socket_t
 class monitor_t
 {
   public:
-    monitor_t() : socketPtr(NULL), monitor_socket(NULL) {}
+    monitor_t() : socketPtr(ZMQ_NULLPTR), monitor_socket(ZMQ_NULLPTR) {}
 
     virtual ~monitor_t()
     {
         if (socketPtr)
-            zmq_socket_monitor(socketPtr, NULL, 0);
+            zmq_socket_monitor(socketPtr, ZMQ_NULLPTR, 0);
 
         if (monitor_socket)
             zmq_close(monitor_socket);
@@ -782,8 +780,8 @@ class monitor_t
     monitor_t(monitor_t &&rhs) ZMQ_NOTHROW : socketPtr(rhs.socketPtr),
                                              monitor_socket(rhs.monitor_socket)
     {
-        rhs.socketPtr = NULL;
-        rhs.monitor_socket = NULL;
+        rhs.socketPtr = ZMQ_NULLPTR;
+        rhs.monitor_socket = ZMQ_NULLPTR;
     }
 
     socket_t &operator=(socket_t &&rhs) ZMQ_DELETED_FUNCTION;
@@ -953,9 +951,9 @@ class monitor_t
     void abort()
     {
         if (socketPtr)
-            zmq_socket_monitor(socketPtr, NULL, 0);
+            zmq_socket_monitor(socketPtr, ZMQ_NULLPTR, 0);
 
-        socketPtr = NULL;
+        socketPtr = ZMQ_NULLPTR;
     }
 #endif
     virtual void on_monitor_started() {}


### PR DESCRIPTION
- Replaced NULL and 0s used as pointers with ZMQ_NULLPTR (defined as nullptr on C++11, as 0 otherwise)
- Added override to the when() member function