### PR TITLE
Problem: Redundant inline specifiers for member functions

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -237,14 +237,14 @@ class message_t
     friend class socket_t;
 
   public:
-    inline message_t()
+    message_t()
     {
         int rc = zmq_msg_init(&msg);
         if (rc != 0)
             throw error_t();
     }
 
-    inline explicit message_t(size_t size_)
+    explicit message_t(size_t size_)
     {
         int rc = zmq_msg_init_size(&msg, size_);
         if (rc != 0)
@@ -268,7 +268,7 @@ class message_t
         }
     }
 
-    inline message_t(const void *data_, size_t size_)
+    message_t(const void *data_, size_t size_)
     {
         int rc = zmq_msg_init_size(&msg, size_);
         if (rc != 0)
@@ -276,7 +276,7 @@ class message_t
         memcpy(data(), data_, size_);
     }
 
-    inline message_t(void *data_, size_t size_, free_fn *ffn_, void *hint_ = ZMQ_NULLPTR)
+    message_t(void *data_, size_t size_, free_fn *ffn_, void *hint_ = ZMQ_NULLPTR)
     {
         int rc = zmq_msg_init_data(&msg, data_, size_, ffn_, hint_);
         if (rc != 0)
@@ -291,27 +291,27 @@ class message_t
 #endif
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    inline message_t(message_t &&rhs) : msg(rhs.msg)
+    message_t(message_t &&rhs) : msg(rhs.msg)
     {
         int rc = zmq_msg_init(&rhs.msg);
         if (rc != 0)
             throw error_t();
     }
 
-    inline message_t &operator=(message_t &&rhs) ZMQ_NOTHROW
+    message_t &operator=(message_t &&rhs) ZMQ_NOTHROW
     {
         std::swap(msg, rhs.msg);
         return *this;
     }
 #endif
 
-    inline ~message_t() ZMQ_NOTHROW
+    ~message_t() ZMQ_NOTHROW
     {
         int rc = zmq_msg_close(&msg);
         ZMQ_ASSERT(rc == 0);
     }
 
-    inline void rebuild()
+    void rebuild()
     {
         int rc = zmq_msg_close(&msg);
         if (rc != 0)
@@ -321,7 +321,7 @@ class message_t
             throw error_t();
     }
 
-    inline void rebuild(size_t size_)
+    void rebuild(size_t size_)
     {
         int rc = zmq_msg_close(&msg);
         if (rc != 0)
@@ -331,7 +331,7 @@ class message_t
             throw error_t();
     }
 
-    inline void rebuild(const void *data_, size_t size_)
+    void rebuild(const void *data_, size_t size_)
     {
         int rc = zmq_msg_close(&msg);
         if (rc != 0)
@@ -342,7 +342,7 @@ class message_t
         memcpy(data(), data_, size_);
     }
 
-    inline void rebuild(void *data_, size_t size_, free_fn *ffn_, void *hint_ = ZMQ_NULLPTR)
+    void rebuild(void *data_, size_t size_, free_fn *ffn_, void *hint_ = ZMQ_NULLPTR)
     {
         int rc = zmq_msg_close(&msg);
         if (rc != 0)
@@ -352,34 +352,34 @@ class message_t
             throw error_t();
     }
 
-    inline void move(message_t const *msg_)
+    void move(message_t const *msg_)
     {
         int rc = zmq_msg_move(&msg, const_cast<zmq_msg_t *>(&(msg_->msg)));
         if (rc != 0)
             throw error_t();
     }
 
-    inline void copy(message_t const *msg_)
+    void copy(message_t const *msg_)
     {
         int rc = zmq_msg_copy(&msg, const_cast<zmq_msg_t *>(&(msg_->msg)));
         if (rc != 0)
             throw error_t();
     }
 
-    inline bool more() const ZMQ_NOTHROW
+    bool more() const ZMQ_NOTHROW
     {
         int rc = zmq_msg_more(const_cast<zmq_msg_t *>(&msg));
         return rc != 0;
     }
 
-    inline void *data() ZMQ_NOTHROW { return zmq_msg_data(&msg); }
+    void *data() ZMQ_NOTHROW { return zmq_msg_data(&msg); }
 
-    inline const void *data() const ZMQ_NOTHROW
+    const void *data() const ZMQ_NOTHROW
     {
         return zmq_msg_data(const_cast<zmq_msg_t *>(&msg));
     }
 
-    inline size_t size() const ZMQ_NOTHROW
+    size_t size() const ZMQ_NOTHROW
     {
         return zmq_msg_size(const_cast<zmq_msg_t *>(&msg));
     }
@@ -392,24 +392,24 @@ class message_t
     }
 
     ZMQ_DEPRECATED("from 4.3.0, use operator== instead")
-    inline bool equal(const message_t *other) const ZMQ_NOTHROW
+    bool equal(const message_t *other) const ZMQ_NOTHROW
     {
         return *this == *other;
     }
 
-    inline bool operator==(const message_t &other) const ZMQ_NOTHROW
+    bool operator==(const message_t &other) const ZMQ_NOTHROW
     {
         const size_t my_size = size();
         return my_size == other.size() && 0 == memcmp(data(), other.data(), my_size);
     }
 
-    inline bool operator!=(const message_t &other) const ZMQ_NOTHROW
+    bool operator!=(const message_t &other) const ZMQ_NOTHROW
     {
         return !(*this == other);
     }
 
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(3, 2, 0)
-    inline int get(int property_)
+    int get(int property_)
     {
         int value = zmq_msg_get(&msg, property_);
         if (value == -1)
@@ -419,7 +419,7 @@ class message_t
 #endif
 
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 1, 0)
-    inline const char *gets(const char *property_)
+    const char *gets(const char *property_)
     {
         const char *value = zmq_msg_gets(&msg, property_);
         if (value == ZMQ_NULLPTR)
@@ -429,24 +429,24 @@ class message_t
 #endif
 
 #if defined(ZMQ_BUILD_DRAFT_API) && ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 0)
-    inline uint32_t routing_id() const
+    uint32_t routing_id() const
     {
         return zmq_msg_routing_id(const_cast<zmq_msg_t*>(&msg));
     }
 
-    inline void set_routing_id(uint32_t routing_id)
+    void set_routing_id(uint32_t routing_id)
     {
         int rc = zmq_msg_set_routing_id(&msg, routing_id);
         if (rc != 0)
             throw error_t();
     }
 
-    inline const char* group() const
+    const char* group() const
     {
         return zmq_msg_group(const_cast<zmq_msg_t*>(&msg));
     }
 
-    inline void set_group(const char* group)
+    void set_group(const char* group)
     {
         int rc = zmq_msg_set_group(&msg, group);
         if (rc != 0)
@@ -457,7 +457,7 @@ class message_t
     /** Dump content to string. Ascii chars are readable, the rest is printed as hex.
          *  Probably ridiculously slow.
          */
-    inline std::string str() const
+    std::string str() const
     {
         // Partly mutuated from the same method in zmq::multipart_t
         std::stringstream os;
@@ -506,7 +506,7 @@ class message_t
 class context_t
 {
   public:
-    inline context_t()
+    context_t()
     {
         ptr = zmq_ctx_new();
         if (ptr == ZMQ_NULLPTR)
@@ -514,7 +514,7 @@ class context_t
     }
 
 
-    inline explicit context_t(int io_threads_,
+    explicit context_t(int io_threads_,
                               int max_sockets_ = ZMQ_MAX_SOCKETS_DFLT)
     {
         ptr = zmq_ctx_new();
@@ -529,26 +529,26 @@ class context_t
     }
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    inline context_t(context_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr) { rhs.ptr = ZMQ_NULLPTR; }
-    inline context_t &operator=(context_t &&rhs) ZMQ_NOTHROW
+    context_t(context_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr) { rhs.ptr = ZMQ_NULLPTR; }
+    context_t &operator=(context_t &&rhs) ZMQ_NOTHROW
     {
         std::swap(ptr, rhs.ptr);
         return *this;
     }
 #endif
 
-    inline int setctxopt(int option_, int optval_)
+    int setctxopt(int option_, int optval_)
     {
         int rc = zmq_ctx_set(ptr, option_, optval_);
         ZMQ_ASSERT(rc == 0);
         return rc;
     }
 
-    inline int getctxopt(int option_) { return zmq_ctx_get(ptr, option_); }
+    int getctxopt(int option_) { return zmq_ctx_get(ptr, option_); }
 
-    inline ~context_t() ZMQ_NOTHROW { close(); }
+    ~context_t() ZMQ_NOTHROW { close(); }
 
-    inline void close() ZMQ_NOTHROW
+    void close() ZMQ_NOTHROW
     {
         if (ptr == ZMQ_NULLPTR)
             return;
@@ -565,11 +565,11 @@ class context_t
     //  Be careful with this, it's probably only useful for
     //  using the C api together with an existing C++ api.
     //  Normally you should never need to use this.
-    inline ZMQ_EXPLICIT operator void *() ZMQ_NOTHROW { return ptr; }
+    ZMQ_EXPLICIT operator void *() ZMQ_NOTHROW { return ptr; }
 
-    inline ZMQ_EXPLICIT operator void const *() const ZMQ_NOTHROW { return ptr; }
+    ZMQ_EXPLICIT operator void const *() const ZMQ_NOTHROW { return ptr; }
 
-    inline operator bool() const ZMQ_NOTHROW { return ptr != ZMQ_NULLPTR; }
+    operator bool() const ZMQ_NOTHROW { return ptr != ZMQ_NULLPTR; }
 
   private:
     void *ptr;
@@ -609,7 +609,7 @@ class socket_t
     friend class monitor_t;
 
   public:
-    inline socket_t(context_t &context_, int type_)
+    socket_t(context_t &context_, int type_)
         : ptr(zmq_socket(static_cast<void*>(context_), type_))
         , ctxptr(static_cast<void*>(context_))
     {
@@ -618,32 +618,32 @@ class socket_t
     }
 
 #ifdef ZMQ_CPP11
-    inline socket_t(context_t &context_, socket_type type_)
+    socket_t(context_t &context_, socket_type type_)
         : socket_t(context_, static_cast<int>(type_))
     {
     }
 #endif
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    inline socket_t(socket_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr), ctxptr(rhs.ctxptr)
+    socket_t(socket_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr), ctxptr(rhs.ctxptr)
     {
         rhs.ptr = ZMQ_NULLPTR;
         rhs.ctxptr = ZMQ_NULLPTR;
     }
-    inline socket_t &operator=(socket_t &&rhs) ZMQ_NOTHROW
+    socket_t &operator=(socket_t &&rhs) ZMQ_NOTHROW
     {
         std::swap(ptr, rhs.ptr);
         return *this;
     }
 #endif
 
-    inline ~socket_t() ZMQ_NOTHROW { close(); }
+    ~socket_t() ZMQ_NOTHROW { close(); }
 
-    inline operator void *() ZMQ_NOTHROW { return ptr; }
+    operator void *() ZMQ_NOTHROW { return ptr; }
 
-    inline operator void const *() const ZMQ_NOTHROW { return ptr; }
+    operator void const *() const ZMQ_NOTHROW { return ptr; }
 
-    inline void close() ZMQ_NOTHROW
+    void close() ZMQ_NOTHROW
     {
         if (ptr == ZMQ_NULLPTR)
             // already closed
@@ -658,14 +658,14 @@ class socket_t
         setsockopt(option_, &optval, sizeof(T));
     }
 
-    inline void setsockopt(int option_, const void *optval_, size_t optvallen_)
+    void setsockopt(int option_, const void *optval_, size_t optvallen_)
     {
         int rc = zmq_setsockopt(ptr, option_, optval_, optvallen_);
         if (rc != 0)
             throw error_t();
     }
 
-    inline void getsockopt(int option_, void *optval_, size_t *optvallen_) const
+    void getsockopt(int option_, void *optval_, size_t *optvallen_) const
     {
         int rc = zmq_getsockopt(ptr, option_, optval_, optvallen_);
         if (rc != 0)
@@ -680,45 +680,45 @@ class socket_t
         return optval;
     }
 
-    inline void bind(std::string const &addr) { bind(addr.c_str()); }
+    void bind(std::string const &addr) { bind(addr.c_str()); }
 
-    inline void bind(const char *addr_)
+    void bind(const char *addr_)
     {
         int rc = zmq_bind(ptr, addr_);
         if (rc != 0)
             throw error_t();
     }
 
-    inline void unbind(std::string const &addr) { unbind(addr.c_str()); }
+    void unbind(std::string const &addr) { unbind(addr.c_str()); }
 
-    inline void unbind(const char *addr_)
+    void unbind(const char *addr_)
     {
         int rc = zmq_unbind(ptr, addr_);
         if (rc != 0)
             throw error_t();
     }
 
-    inline void connect(std::string const &addr) { connect(addr.c_str()); }
+    void connect(std::string const &addr) { connect(addr.c_str()); }
 
-    inline void connect(const char *addr_)
+    void connect(const char *addr_)
     {
         int rc = zmq_connect(ptr, addr_);
         if (rc != 0)
             throw error_t();
     }
 
-    inline void disconnect(std::string const &addr) { disconnect(addr.c_str()); }
+    void disconnect(std::string const &addr) { disconnect(addr.c_str()); }
 
-    inline void disconnect(const char *addr_)
+    void disconnect(const char *addr_)
     {
         int rc = zmq_disconnect(ptr, addr_);
         if (rc != 0)
             throw error_t();
     }
 
-    inline bool connected() const ZMQ_NOTHROW { return (ptr != ZMQ_NULLPTR); }
+    bool connected() const ZMQ_NOTHROW { return (ptr != ZMQ_NULLPTR); }
 
-    inline size_t send(const void *buf_, size_t len_, int flags_ = 0)
+    size_t send(const void *buf_, size_t len_, int flags_ = 0)
     {
         int nbytes = zmq_send(ptr, buf_, len_, flags_);
         if (nbytes >= 0)
@@ -728,7 +728,7 @@ class socket_t
         throw error_t();
     }
 
-    inline bool send(message_t &msg_, int flags_ = 0)
+    bool send(message_t &msg_, int flags_ = 0)
     {
         int nbytes = zmq_msg_send(&(msg_.msg), ptr, flags_);
         if (nbytes >= 0)
@@ -745,10 +745,10 @@ class socket_t
     }
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    inline bool send(message_t &&msg_, int flags_ = 0) { return send(msg_, flags_); }
+    bool send(message_t &&msg_, int flags_ = 0) { return send(msg_, flags_); }
 #endif
 
-    inline size_t recv(void *buf_, size_t len_, int flags_ = 0)
+    size_t recv(void *buf_, size_t len_, int flags_ = 0)
     {
         int nbytes = zmq_recv(ptr, buf_, len_, flags_);
         if (nbytes >= 0)
@@ -758,7 +758,7 @@ class socket_t
         throw error_t();
     }
 
-    inline bool recv(message_t *msg_, int flags_ = 0)
+    bool recv(message_t *msg_, int flags_ = 0)
     {
         int nbytes = zmq_msg_recv(&(msg_->msg), ptr, flags_);
         if (nbytes >= 0)
@@ -769,14 +769,14 @@ class socket_t
     }
 
 #if defined(ZMQ_BUILD_DRAFT_API) && ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 0)
-    inline void join(const char* group)
+    void join(const char* group)
     {
         int rc = zmq_join(ptr, group);
         if (rc != 0)
             throw error_t();
     }
 
-    inline void leave(const char* group)
+    void leave(const char* group)
     {
         int rc = zmq_leave(ptr, group);
         if (rc != 0)


### PR DESCRIPTION
Solution: Remove specifiers, since they are implicitly inline