### PR TITLE
Problem: Missing swap functions

### DIFF
--- a/tests/context.cpp
+++ b/tests/context.cpp
@@ -1,6 +1,11 @@
 #include <catch.hpp>
 #include <zmq.hpp>
 
+#if (__cplusplus >= 201703L)
+static_assert(std::is_nothrow_swappable<zmq::context_t>::value,
+              "context_t should be nothrow swappable");
+#endif
+
 TEST_CASE("context construct default and destroy", "[context]")
 {
     zmq::context_t context;
@@ -12,3 +17,13 @@ TEST_CASE("context create, close and destroy", "[context]")
     context.close();
     CHECK(NULL == (void *) context);
 }
+
+#ifdef ZMQ_CPP11
+TEST_CASE("context swap", "[context]")
+{
+    zmq::context_t context1;
+    zmq::context_t context2;
+    using std::swap;
+    swap(context1, context2);
+}
+#endif

--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -8,12 +8,32 @@ static_assert(!std::is_copy_constructible<zmq::message_t>::value,
 static_assert(!std::is_copy_assignable<zmq::message_t>::value,
               "message_t should not be copy-assignable");
 #endif
+#if (__cplusplus >= 201703L)
+static_assert(std::is_nothrow_swappable<zmq::message_t>::value,
+              "message_t should be nothrow swappable");
+#endif
 
 TEST_CASE("message default constructed", "[message]")
 {
     const zmq::message_t message;
     CHECK(0u == message.size());
 }
+
+#ifdef ZMQ_CPP11
+TEST_CASE("message swap", "[message]")
+{
+    const std::string data = "foo";
+    zmq::message_t message1;
+    zmq::message_t message2(data.data(), data.size());
+    using std::swap;
+    swap(message1, message2);
+    CHECK(message1.size() == data.size());
+    CHECK(message2.size() == 0);
+    swap(message1, message2);
+    CHECK(message1.size() == 0);
+    CHECK(message2.size() == data.size());
+}
+#endif
 
 namespace {
 const char *const data = "Hi";

--- a/tests/monitor.cpp
+++ b/tests/monitor.cpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
+#include <functional>
 
 class mock_monitor_t : public zmq::monitor_t
 {

--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -5,6 +5,11 @@
 #include <array>
 #include <memory>
 
+#if (__cplusplus >= 201703L)
+static_assert(std::is_nothrow_swappable<zmq::poller_t<>>::value,
+              "poller_t should be nothrow swappable");
+#endif
+
 TEST_CASE("poller create destroy", "[poller]")
 {
     zmq::poller_t<> poller;
@@ -26,6 +31,14 @@ TEST_CASE("poller move assign empty", "[poller]")
     zmq::poller_t<> a;
     zmq::poller_t<> b;
     b = std::move(a);
+}
+
+TEST_CASE("poller swap", "[poller]")
+{
+    zmq::poller_t<> a;
+    zmq::poller_t<> b;
+    using std::swap;
+    swap(a, b);
 }
 
 TEST_CASE("poller move construct non empty", "[poller]")

--- a/tests/socket.cpp
+++ b/tests/socket.cpp
@@ -4,6 +4,11 @@
 #include <future>
 #endif
 
+#if (__cplusplus >= 201703L)
+static_assert(std::is_nothrow_swappable<zmq::socket_t>::value,
+              "socket_t should be nothrow swappable");
+#endif
+
 TEST_CASE("socket create destroy", "[socket]")
 {
     zmq::context_t context;
@@ -15,6 +20,15 @@ TEST_CASE("socket create by enum and destroy", "[socket]")
 {
     zmq::context_t context;
     zmq::socket_t socket(context, zmq::socket_type::router);
+}
+
+TEST_CASE("socket swap", "[socket]")
+{
+    zmq::context_t context;
+    zmq::socket_t socket1(context, zmq::socket_type::router);
+    zmq::socket_t socket2(context, zmq::socket_type::dealer);
+    using std::swap;
+    swap(socket1, socket2);
 }
 #endif
 

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -73,8 +73,6 @@
 #ifdef ZMQ_CPP11
 #include <chrono>
 #include <tuple>
-#include <functional>
-#include <unordered_map>
 #include <memory>
 #endif
 
@@ -476,6 +474,12 @@ class message_t
         return os.str();
     }
 
+    void swap(message_t &other) ZMQ_NOTHROW
+    {
+        // this assumes zmq::msg_t from libzmq is trivially relocatable
+        std::swap(msg, other.msg);
+    }
+
   private:
     //  The underlying message
     zmq_msg_t msg;
@@ -485,6 +489,11 @@ class message_t
     message_t(const message_t &) ZMQ_DELETED_FUNCTION;
     void operator=(const message_t &) ZMQ_DELETED_FUNCTION;
 };
+
+inline void swap(message_t &a, message_t &b) ZMQ_NOTHROW
+{
+    a.swap(b);
+}
 
 class context_t
 {
@@ -554,12 +563,21 @@ class context_t
 
     operator bool() const ZMQ_NOTHROW { return ptr != ZMQ_NULLPTR; }
 
+    void swap(context_t &other) ZMQ_NOTHROW
+    {
+        std::swap(ptr, other.ptr);
+    }
+
   private:
     void *ptr;
 
     context_t(const context_t &) ZMQ_DELETED_FUNCTION;
     void operator=(const context_t &) ZMQ_DELETED_FUNCTION;
 };
+
+inline void swap(context_t &a, context_t &b) ZMQ_NOTHROW {
+    a.swap(b);
+}
 
 #ifdef ZMQ_CPP11
 enum class socket_type : int
@@ -767,6 +785,12 @@ class socket_t
     }
 #endif
 
+    void swap(socket_t &other) ZMQ_NOTHROW
+    {
+        std::swap(ptr, other.ptr);
+        std::swap(ctxptr, other.ctxptr);
+    }
+
   private:
     void *ptr;
     void *ctxptr;
@@ -774,6 +798,10 @@ class socket_t
     socket_t(const socket_t &) ZMQ_DELETED_FUNCTION;
     void operator=(const socket_t &) ZMQ_DELETED_FUNCTION;
 };
+
+inline void swap(socket_t &a, socket_t &b) ZMQ_NOTHROW {
+    a.swap(b);
+}
 
 ZMQ_DEPRECATED("from 4.3.1, use proxy taking socket_t objects")
 inline void proxy(void *frontend, void *backend, void *capture)
@@ -1119,6 +1147,8 @@ class monitor_t
 template<typename T = void> class poller_t
 {
   public:
+    poller_t() = default;
+
     void add(zmq::socket_t &socket, short events, T *user_data)
     {
         if (0
@@ -1164,17 +1194,19 @@ template<typename T = void> class poller_t
     }
 
   private:
-    std::unique_ptr<void, std::function<void(void *)>> poller_ptr{
+    std::unique_ptr<void, void(*)(void *)> poller_ptr{
       []() {
           auto poller_new = zmq_poller_new();
           if (poller_new)
               return poller_new;
           throw error_t();
-      }(),
-      [](void *ptr) {
-          int rc = zmq_poller_destroy(&ptr);
-          ZMQ_ASSERT(rc == 0);
-      }};
+      }(), &destroy_poller};
+
+    static void destroy_poller(void *ptr)
+    {
+        int rc = zmq_poller_destroy(&ptr);
+        ZMQ_ASSERT(rc == 0);
+    }
 };
 #endif //  defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11) && defined(ZMQ_HAVE_POLLER)
 

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -30,6 +30,10 @@
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
+#ifdef ZMQ_CPP11
+#include <functional>
+#include <unordered_map>
+#endif
 
 namespace zmq
 {
@@ -245,7 +249,7 @@ class multipart_t
         m_parts.pop_back();
         return message;
     }
-    
+
     // get message part from front
     const message_t &front()
     {


### PR DESCRIPTION
Solution: Implement for socket_t, context_t, message_t and poller_t
Additionally remove dependency on `<functional>` by refactoring poller_t
and remove unused `<unordered_map>` include.