### PR TITLE
Problem: message_t move and copy are mutating but take const

### DIFF
--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -150,7 +150,22 @@ TEST_CASE("message is shared", "[message]")
     size_t msg_sz = 1024; // large enough to be a type_lmsg
     zmq::message_t msg1(msg_sz);
     zmq::message_t msg2;
-    msg2.copy(&msg1);
+    msg2.copy(msg1);
+    CHECK(msg1.get(ZMQ_SHARED) == 1);
     CHECK(msg2.get(ZMQ_SHARED) == 1);
+    CHECK(msg1.size() == msg_sz);
+    CHECK(msg2.size() == msg_sz);
+}
+
+TEST_CASE("message move is not shared", "[message]")
+{
+    size_t msg_sz = 1024; // large enough to be a type_lmsg
+    zmq::message_t msg1(msg_sz);
+    zmq::message_t msg2;
+    msg2.move(msg1);
+    CHECK(msg1.get(ZMQ_SHARED) == 0);
+    CHECK(msg2.get(ZMQ_SHARED) == 0);
+    CHECK(msg2.size() == msg_sz);
+    CHECK(msg1.size() == 0);
 }
 #endif

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -335,6 +335,7 @@ class message_t
             throw error_t();
     }
 
+    ZMQ_DEPRECATED("from 4.3.1, use move taking non-const reference instead")
     void move(message_t const *msg_)
     {
         int rc = zmq_msg_move(&msg, const_cast<zmq_msg_t *>(&(msg_->msg)));
@@ -342,9 +343,24 @@ class message_t
             throw error_t();
     }
 
+    void move(message_t &msg_)
+    {
+        int rc = zmq_msg_move(&msg, &msg_.msg);
+        if (rc != 0)
+            throw error_t();
+    }
+
+    ZMQ_DEPRECATED("from 4.3.1, use copy taking non-const reference instead")
     void copy(message_t const *msg_)
     {
         int rc = zmq_msg_copy(&msg, const_cast<zmq_msg_t *>(&(msg_->msg)));
+        if (rc != 0)
+            throw error_t();
+    }
+
+    void copy(message_t &msg_)
+    {
+        int rc = zmq_msg_copy(&msg, &msg_.msg);
         if (rc != 0)
             throw error_t();
     }


### PR DESCRIPTION
Solution: Deprecate old functions and add overloads taking non-const
references