### PR TITLE
Problem: poller_t does not need to be a template class

### DIFF
--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -6,37 +6,36 @@
 #include <memory>
 
 #if (__cplusplus >= 201703L)
-static_assert(std::is_nothrow_swappable<zmq::poller_t<>>::value,
-              "poller_t should be nothrow swappable");
+static_assert(std::is_nothrow_swappable_v<zmq::poller_t>);
 #endif
 
 TEST_CASE("poller create destroy", "[poller]")
 {
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
 }
 
-static_assert(!std::is_copy_constructible<zmq::poller_t<>>::value,
+static_assert(!std::is_copy_constructible<zmq::poller_t>::value,
               "poller_t should not be copy-constructible");
-static_assert(!std::is_copy_assignable<zmq::poller_t<>>::value,
+static_assert(!std::is_copy_assignable<zmq::poller_t>::value,
               "poller_t should not be copy-assignable");
 
 TEST_CASE("poller move construct empty", "[poller]")
 {
-    zmq::poller_t<> a;
-    zmq::poller_t<> b = std::move(a);
+    zmq::poller_t a;
+    zmq::poller_t b = std::move(a);
 }
 
 TEST_CASE("poller move assign empty", "[poller]")
 {
-    zmq::poller_t<> a;
-    zmq::poller_t<> b;
+    zmq::poller_t a;
+    zmq::poller_t b;
     b = std::move(a);
 }
 
 TEST_CASE("poller swap", "[poller]")
 {
-    zmq::poller_t<> a;
-    zmq::poller_t<> b;
+    zmq::poller_t a;
+    zmq::poller_t b;
     using std::swap;
     swap(a, b);
 }
@@ -46,9 +45,9 @@ TEST_CASE("poller move construct non empty", "[poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
 
-    zmq::poller_t<> a;
-    a.add(socket, ZMQ_POLLIN, nullptr);
-    zmq::poller_t<> b = std::move(a);
+    zmq::poller_t a;
+    a.add(socket, ZMQ_POLLIN);
+    zmq::poller_t b = std::move(a);
 }
 
 TEST_CASE("poller move assign non empty", "[poller]")
@@ -56,9 +55,9 @@ TEST_CASE("poller move assign non empty", "[poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
 
-    zmq::poller_t<> a;
-    a.add(socket, ZMQ_POLLIN, nullptr);
-    zmq::poller_t<> b;
+    zmq::poller_t a;
+    a.add(socket, ZMQ_POLLIN);
+    zmq::poller_t b;
     b = std::move(a);
 }
 
@@ -66,7 +65,7 @@ TEST_CASE("poller add nullptr", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     CHECK_NOTHROW(poller.add(socket, ZMQ_POLLIN, nullptr));
 }
 
@@ -74,7 +73,7 @@ TEST_CASE("poller add non nullptr", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     int i;
     CHECK_NOTHROW(poller.add(socket, ZMQ_POLLIN, &i));
 }
@@ -85,9 +84,9 @@ TEST_CASE("poller add handler invalid events type", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     short invalid_events_type = 2 << 10;
-    CHECK_THROWS_AS(poller.add(socket, invalid_events_type, nullptr), zmq::error_t);
+    CHECK_THROWS_AS(poller.add(socket, invalid_events_type), zmq::error_t);
 }
 #endif
 
@@ -95,15 +94,15 @@ TEST_CASE("poller add handler twice throws", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
-    zmq::poller_t<> poller;
-    poller.add(socket, ZMQ_POLLIN, nullptr);
+    zmq::poller_t poller;
+    poller.add(socket, ZMQ_POLLIN);
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(poller.add(socket, ZMQ_POLLIN, nullptr), zmq::error_t);
+    CHECK_THROWS_AS(poller.add(socket, ZMQ_POLLIN), zmq::error_t);
 }
 
 TEST_CASE("poller wait with no handlers throws", "[poller]")
 {
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     std::vector<zmq_poller_event_t> events;
     /// \todo the actual error code should be checked
     CHECK_THROWS_AS(poller.wait_all(events, std::chrono::milliseconds{10}),
@@ -114,7 +113,7 @@ TEST_CASE("poller remove unregistered throws", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     /// \todo the actual error code should be checked
     CHECK_THROWS_AS(poller.remove(socket), zmq::error_t);
 }
@@ -123,8 +122,8 @@ TEST_CASE("poller remove registered empty", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
-    zmq::poller_t<> poller;
-    poller.add(socket, ZMQ_POLLIN, nullptr);
+    zmq::poller_t poller;
+    poller.add(socket, ZMQ_POLLIN);
     CHECK_NOTHROW(poller.remove(socket));
 }
 
@@ -132,7 +131,7 @@ TEST_CASE("poller remove registered non empty", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     int empty{};
     poller.add(socket, ZMQ_POLLIN, &empty);
     CHECK_NOTHROW(poller.remove(socket));
@@ -144,7 +143,7 @@ TEST_CASE("poller poll basic", "[poller]")
 
     CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
 
-    zmq::poller_t<int> poller;
+    zmq::poller_t poller;
     std::vector<zmq_poller_event_t> events{1};
     int i = 0;
     CHECK_NOTHROW(poller.add(s.server, ZMQ_POLLIN, &i));
@@ -156,18 +155,18 @@ TEST_CASE("poller poll basic", "[poller]")
 TEST_CASE("poller add invalid socket throws", "[poller]")
 {
     zmq::context_t context;
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     zmq::socket_t a{context, zmq::socket_type::router};
     zmq::socket_t b{std::move(a)};
-    CHECK_THROWS_AS(poller.add(a, ZMQ_POLLIN, nullptr), zmq::error_t);
+    CHECK_THROWS_AS(poller.add(a, ZMQ_POLLIN), zmq::error_t);
 }
 
 TEST_CASE("poller remove invalid socket throws", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
-    zmq::poller_t<> poller;
-    CHECK_NOTHROW(poller.add(socket, ZMQ_POLLIN, nullptr));
+    zmq::poller_t poller;
+    CHECK_NOTHROW(poller.add(socket, ZMQ_POLLIN));
     std::vector<zmq::socket_t> sockets;
     sockets.emplace_back(std::move(socket));
     CHECK_THROWS_AS(poller.remove(socket), zmq::error_t);
@@ -178,7 +177,7 @@ TEST_CASE("poller modify empty throws", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::push};
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     CHECK_THROWS_AS(poller.modify(socket, ZMQ_POLLIN), zmq::error_t);
 }
 
@@ -187,7 +186,7 @@ TEST_CASE("poller modify invalid socket throws", "[poller]")
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::socket_t b{std::move(a)};
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     CHECK_THROWS_AS(poller.modify(a, ZMQ_POLLIN), zmq::error_t);
 }
 
@@ -196,8 +195,8 @@ TEST_CASE("poller modify not added throws", "[poller]")
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::socket_t b{context, zmq::socket_type::push};
-    zmq::poller_t<> poller;
-    CHECK_NOTHROW(poller.add(a, ZMQ_POLLIN, nullptr));
+    zmq::poller_t poller;
+    CHECK_NOTHROW(poller.add(a, ZMQ_POLLIN));
     CHECK_THROWS_AS(poller.modify(b, ZMQ_POLLIN), zmq::error_t);
 }
 
@@ -205,8 +204,8 @@ TEST_CASE("poller modify simple", "[poller]")
 {
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
-    zmq::poller_t<> poller;
-    CHECK_NOTHROW(poller.add(a, ZMQ_POLLIN, nullptr));
+    zmq::poller_t poller;
+    CHECK_NOTHROW(poller.add(a, ZMQ_POLLIN));
     CHECK_NOTHROW(poller.modify(a, ZMQ_POLLIN | ZMQ_POLLOUT));
 }
 
@@ -216,8 +215,8 @@ TEST_CASE("poller poll client server", "[poller]")
     common_server_client_setup s;
 
     // Setup poller
-    zmq::poller_t<> poller;
-    CHECK_NOTHROW(poller.add(s.server, ZMQ_POLLIN, s.server));
+    zmq::poller_t poller;
+    CHECK_NOTHROW(poller.add(s.server, ZMQ_POLLIN, static_cast<void*>(s.server)));
 
     // client sends message
     CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
@@ -239,8 +238,8 @@ TEST_CASE("poller wait one return", "[poller]")
     common_server_client_setup s;
 
     // Setup poller
-    zmq::poller_t<> poller;
-    CHECK_NOTHROW(poller.add(s.server, ZMQ_POLLIN, nullptr));
+    zmq::poller_t poller;
+    CHECK_NOTHROW(poller.add(s.server, ZMQ_POLLIN));
 
     // client sends message
     CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
@@ -254,9 +253,9 @@ TEST_CASE("poller wait on move constructed", "[poller]")
 {
     common_server_client_setup s;
     CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
-    zmq::poller_t<> a;
-    CHECK_NOTHROW(a.add(s.server, ZMQ_POLLIN, nullptr));
-    zmq::poller_t<> b{std::move(a)};
+    zmq::poller_t a;
+    CHECK_NOTHROW(a.add(s.server, ZMQ_POLLIN));
+    zmq::poller_t b{std::move(a)};
     std::vector<zmq_poller_event_t> events(1);
     /// \todo the actual error code should be checked
     CHECK_THROWS_AS(a.wait_all(events, std::chrono::milliseconds{10}), zmq::error_t);
@@ -267,9 +266,9 @@ TEST_CASE("poller wait on move assigned", "[poller]")
 {
     common_server_client_setup s;
     CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
-    zmq::poller_t<> a;
-    CHECK_NOTHROW(a.add(s.server, ZMQ_POLLIN, nullptr));
-    zmq::poller_t<> b;
+    zmq::poller_t a;
+    CHECK_NOTHROW(a.add(s.server, ZMQ_POLLIN));
+    zmq::poller_t b;
     b = {std::move(a)};
     /// \todo the TEST_CASE error code should be checked
     std::vector<zmq_poller_event_t> events(1);
@@ -287,9 +286,9 @@ TEST_CASE("poller remove from handler", "[poller]")
         setup_list.emplace_back(common_server_client_setup{});
 
     // Setup poller
-    zmq::poller_t<> poller;
+    zmq::poller_t poller;
     for (auto i = 0; i < ITER_NO; ++i) {
-        CHECK_NOTHROW(poller.add(setup_list[i].server, ZMQ_POLLIN, nullptr));
+        CHECK_NOTHROW(poller.add(setup_list[i].server, ZMQ_POLLIN));
     }
     // Clients send messages
     for (auto &s : setup_list) {

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1187,18 +1187,24 @@ class monitor_t
 };
 
 #if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11) && defined(ZMQ_HAVE_POLLER)
-template<typename T = void> class poller_t
+class poller_t
 {
   public:
     poller_t() = default;
 
-    void add(zmq::socket_t &socket, short events, T *user_data)
+    template<typename T = void>
+    void add(zmq::socket_t &socket, short events, T *user_data = nullptr)
     {
         if (0
             != zmq_poller_add(poller_ptr.get(), static_cast<void *>(socket),
                               user_data, events)) {
             throw error_t();
         }
+    }
+
+    void add(zmq::socket_t &socket, short events, std::nullptr_t)
+    {
+        add(socket, events);
     }
 
     void remove(zmq::socket_t &socket)

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -434,7 +434,7 @@ class active_poller_t
   private:
     bool need_rebuild{false};
 
-    poller_t<handler_t> base_poller{};
+    poller_t base_poller{};
     std::unordered_map<void *, std::shared_ptr<handler_t>> handlers{};
     std::vector<zmq_poller_event_t> poller_events{};
     std::vector<std::shared_ptr<handler_t>> poller_handlers{};


### PR DESCRIPTION
Solution: Remove template, and make the add function a template instead.

The template parameter of poller_t as it is does not really add any type safety, so we can just drop it.