### PR TITLE
Use C++ cast instead of old style cast

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -760,7 +760,7 @@ class socket_t
     {
         int nbytes = zmq_send(ptr, buf_, len_, flags_);
         if (nbytes >= 0)
-            return (size_t) nbytes;
+            return static_cast<size_t>(nbytes);
         if (zmq_errno() == EAGAIN)
             return 0;
         throw error_t();
@@ -790,7 +790,7 @@ class socket_t
     {
         int nbytes = zmq_recv(ptr, buf_, len_, flags_);
         if (nbytes >= 0)
-            return (size_t) nbytes;
+            return static_cast<size_t>(nbytes);
         if (zmq_errno() == EAGAIN)
             return 0;
         throw error_t();


### PR DESCRIPTION
This to avoid the following warning with the '-Wold-style-cast' flag enabled :

./zmq.hpp:763:29: warning: use of old-style cast [-Wold-style-cast]
             return (size_t) nbytes;
                             ^
./zmq.hpp: In member function ‘size_t zmq::socket_t::recv(void*, size_t, int)’:
./zmq.hpp:793:29: warning: use of old-style cast [-Wold-style-cast]
             return (size_t) nbytes;