### PR TITLE
Problem: send/recv functions lack type-safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Supported platforms
    - Any platform supported by libzmq that provides a sufficiently recent gcc (4.8.1 or newer) or clang (3.3 or newer)
    - Visual Studio 2012+ x86/x64
 
+Examples
+========
+```c++
+#include <string>
+#include <zmq.hpp>
+int main()
+{
+   zmq::context_t ctx;
+   zmq::socket_t sock(ctx, zmq::socket_type::push);
+   sock.bind("inproc://test");
+   const std::string_view m = "Hello, world";
+   sock.send(zmq::buffer(m), zmq::send_flags::dontwait);
+}
+```
+
 Contribution policy
 ===================
 
@@ -74,5 +89,3 @@ cpp zmq (which will also include libzmq for you).
 find_package(cppzmq)
 target_link_libraries(*Your Project Name* cppzmq)
 ```
-
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(Threads)
 
 add_executable(
     unit_tests
+    buffer.cpp
     message.cpp
     context.cpp
     socket.cpp

--- a/tests/active_poller.cpp
+++ b/tests/active_poller.cpp
@@ -157,7 +157,7 @@ TEST_CASE("poll basic", "[active_poller]")
 {
     server_client_setup s;
 
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
 
     zmq::active_poller_t active_poller;
     bool message_received = false;
@@ -184,7 +184,7 @@ TEST_CASE("client server", "[active_poller]")
     zmq::active_poller_t::handler_t handler = [&](short e) {
         if (0 != (e & ZMQ_POLLIN)) {
             zmq::message_t zmq_msg;
-            CHECK_NOTHROW(s.server.recv(&zmq_msg)); // get message
+            CHECK_NOTHROW(s.server.recv(zmq_msg)); // get message
             std::string recv_msg(zmq_msg.data<char>(), zmq_msg.size());
             CHECK(send_msg == recv_msg);
         } else if (0 != (e & ~ZMQ_POLLOUT)) {
@@ -197,7 +197,7 @@ TEST_CASE("client server", "[active_poller]")
     CHECK_NOTHROW(active_poller.add(s.server, ZMQ_POLLIN, handler));
 
     // client sends message
-    CHECK_NOTHROW(s.client.send(zmq::message_t{send_msg}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{send_msg}, zmq::send_flags::none));
 
     CHECK(1 == active_poller.wait(std::chrono::milliseconds{-1}));
     CHECK(events == ZMQ_POLLIN);
@@ -236,7 +236,7 @@ TEST_CASE("remove invalid socket throws", "[active_poller]")
 TEST_CASE("wait on added empty handler", "[active_poller]")
 {
     server_client_setup s;
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     zmq::active_poller_t active_poller;
     zmq::active_poller_t::handler_t handler;
     CHECK_NOTHROW(active_poller.add(s.server, ZMQ_POLLIN, handler));
@@ -291,7 +291,7 @@ TEST_CASE("poll client server", "[active_poller]")
     CHECK_NOTHROW(active_poller.add(s.server, ZMQ_POLLIN, s.handler));
 
     // client sends message
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
 
     // wait for message and verify events
     CHECK_NOTHROW(active_poller.wait(std::chrono::milliseconds{500}));
@@ -316,7 +316,7 @@ TEST_CASE("wait one return", "[active_poller]")
       active_poller.add(s.server, ZMQ_POLLIN, [&count](short) { ++count; }));
 
     // client sends message
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
 
     // wait for message and verify events
     CHECK(1 == active_poller.wait(std::chrono::milliseconds{500}));
@@ -326,7 +326,7 @@ TEST_CASE("wait one return", "[active_poller]")
 TEST_CASE("wait on move constructed active_poller", "[active_poller]")
 {
     server_client_setup s;
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     zmq::active_poller_t a;
     zmq::active_poller_t::handler_t handler;
     CHECK_NOTHROW(a.add(s.server, ZMQ_POLLIN, handler));
@@ -340,7 +340,7 @@ TEST_CASE("wait on move constructed active_poller", "[active_poller]")
 TEST_CASE("wait on move assigned active_poller", "[active_poller]")
 {
     server_client_setup s;
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     zmq::active_poller_t a;
     zmq::active_poller_t::handler_t handler;
     CHECK_NOTHROW(a.add(s.server, ZMQ_POLLIN, handler));
@@ -361,14 +361,14 @@ TEST_CASE("received on move constructed active_poller", "[active_poller]")
     zmq::active_poller_t a;
     CHECK_NOTHROW(a.add(s.server, ZMQ_POLLIN, [&count](short) { ++count; }));
     // client sends message
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     // wait for message and verify it is received
     CHECK(1 == a.wait(std::chrono::milliseconds{500}));
     CHECK(1u == count);
     // Move construct active_poller b
     zmq::active_poller_t b{std::move(a)};
     // client sends message again
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     // wait for message and verify it is received
     CHECK(1 == b.wait(std::chrono::milliseconds{500}));
     CHECK(2u == count);
@@ -399,7 +399,7 @@ TEST_CASE("remove from handler", "[active_poller]")
     CHECK(ITER_NO == active_poller.size());
     // Clients send messages
     for (auto &s : setup_list) {
-        CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+        CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     }
 
     // Wait for all servers to receive a message

--- a/tests/buffer.cpp
+++ b/tests/buffer.cpp
@@ -1,0 +1,253 @@
+#include <catch.hpp>
+#include <zmq.hpp>
+
+#ifdef ZMQ_CPP17
+static_assert(std::is_nothrow_swappable_v<zmq::const_buffer>);
+static_assert(std::is_nothrow_swappable_v<zmq::mutable_buffer>);
+static_assert(std::is_trivially_copyable_v<zmq::const_buffer>);
+static_assert(std::is_trivially_copyable_v<zmq::mutable_buffer>);
+#endif
+
+#ifdef ZMQ_CPP11
+
+using BT = int16_t;
+
+TEST_CASE("buffer default ctor", "[buffer]")
+{
+    zmq::mutable_buffer mb;
+    zmq::const_buffer cb;
+    CHECK(mb.size() == 0);
+    CHECK(mb.data() == nullptr);
+    CHECK(cb.size() == 0);
+    CHECK(cb.data() == nullptr);
+}
+
+TEST_CASE("buffer data ctor", "[buffer]")
+{
+    std::vector<BT> v(10);
+    zmq::const_buffer cb(v.data(), v.size() * sizeof(BT));
+    CHECK(cb.size() == v.size() * sizeof(BT));
+    CHECK(cb.data() == v.data());
+    zmq::mutable_buffer mb(v.data(), v.size() * sizeof(BT));
+    CHECK(mb.size() == v.size() * sizeof(BT));
+    CHECK(mb.data() == v.data());
+    zmq::const_buffer from_mut = mb;
+    CHECK(mb.size() == from_mut.size());
+    CHECK(mb.data() == from_mut.data());
+    const auto cmb = mb;
+    static_assert(std::is_same<decltype(cmb.data()), void*>::value, "");
+}
+
+TEST_CASE("const_buffer operator+", "[buffer]")
+{
+    std::vector<BT> v(10);
+    zmq::const_buffer cb(v.data(), v.size() * sizeof(BT));
+    const size_t shift = 4;
+    auto shifted = cb + shift;
+    CHECK(shifted.size() == v.size() * sizeof(BT) - shift);
+    CHECK(shifted.data() == v.data() + shift / sizeof(BT));
+    auto shifted2 = shift + cb;
+    CHECK(shifted.size() == shifted2.size());
+    CHECK(shifted.data() == shifted2.data());
+    auto cbinp = cb;
+    cbinp += shift;
+    CHECK(shifted.size() == cbinp.size());
+    CHECK(shifted.data() == cbinp.data());
+}
+
+TEST_CASE("mutable_buffer operator+", "[buffer]")
+{
+    std::vector<BT> v(10);
+    zmq::mutable_buffer mb(v.data(), v.size() * sizeof(BT));
+    const size_t shift = 4;
+    auto shifted = mb + shift;
+    CHECK(shifted.size() == v.size() * sizeof(BT) - shift);
+    CHECK(shifted.data() == v.data() + shift / sizeof(BT));
+    auto shifted2 = shift + mb;
+    CHECK(shifted.size() == shifted2.size());
+    CHECK(shifted.data() == shifted2.data());
+    auto mbinp = mb;
+    mbinp += shift;
+    CHECK(shifted.size() == mbinp.size());
+    CHECK(shifted.data() == mbinp.data());
+}
+
+TEST_CASE("mutable_buffer creation basic", "[buffer]")
+{
+    std::vector<BT> v(10);
+    zmq::mutable_buffer mb(v.data(), v.size() * sizeof(BT));
+    zmq::mutable_buffer mb2 = zmq::buffer(v.data(), v.size() * sizeof(BT));
+    CHECK(mb.data() == mb2.data());
+    CHECK(mb.size() == mb2.size());
+    zmq::mutable_buffer mb3 = zmq::buffer(mb);
+    CHECK(mb.data() == mb3.data());
+    CHECK(mb.size() == mb3.size());
+    zmq::mutable_buffer mb4 = zmq::buffer(mb, 10 * v.size() * sizeof(BT));
+    CHECK(mb.data() == mb4.data());
+    CHECK(mb.size() == mb4.size());
+    zmq::mutable_buffer mb5 = zmq::buffer(mb, 4);
+    CHECK(mb.data() == mb5.data());
+    CHECK(4 == mb5.size());
+}
+
+TEST_CASE("const_buffer creation basic", "[buffer]")
+{
+    const std::vector<BT> v(10);
+    zmq::const_buffer cb(v.data(), v.size() * sizeof(BT));
+    zmq::const_buffer cb2 = zmq::buffer(v.data(), v.size() * sizeof(BT));
+    CHECK(cb.data() == cb2.data());
+    CHECK(cb.size() == cb2.size());
+    zmq::const_buffer cb3 = zmq::buffer(cb);
+    CHECK(cb.data() == cb3.data());
+    CHECK(cb.size() == cb3.size());
+    zmq::const_buffer cb4 = zmq::buffer(cb, 10 * v.size() * sizeof(BT));
+    CHECK(cb.data() == cb4.data());
+    CHECK(cb.size() == cb4.size());
+    zmq::const_buffer cb5 = zmq::buffer(cb, 4);
+    CHECK(cb.data() == cb5.data());
+    CHECK(4 == cb5.size());
+}
+
+TEST_CASE("mutable_buffer creation C array", "[buffer]")
+{
+    BT d[10] = {};
+    zmq::mutable_buffer b = zmq::buffer(d);
+    CHECK(b.size() == 10 * sizeof(BT));
+    CHECK(b.data() == static_cast<BT*>(d));
+    zmq::const_buffer b2 = zmq::buffer(d, 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == static_cast<BT*>(d));
+}
+
+TEST_CASE("const_buffer creation C array", "[buffer]")
+{
+    const BT d[10] = {};
+    zmq::const_buffer b = zmq::buffer(d);
+    CHECK(b.size() == 10 * sizeof(BT));
+    CHECK(b.data() == static_cast<const BT*>(d));
+    zmq::const_buffer b2 = zmq::buffer(d, 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == static_cast<const BT*>(d));
+}
+
+TEST_CASE("mutable_buffer creation array", "[buffer]")
+{
+    std::array<BT, 10> d = {};
+    zmq::mutable_buffer b = zmq::buffer(d);
+    CHECK(b.size() == d.size() * sizeof(BT));
+    CHECK(b.data() == d.data());
+    zmq::mutable_buffer b2 = zmq::buffer(d, 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == d.data());
+}
+
+TEST_CASE("const_buffer creation array", "[buffer]")
+{
+    const std::array<BT, 10> d = {};
+    zmq::const_buffer b = zmq::buffer(d);
+    CHECK(b.size() == d.size() * sizeof(BT));
+    CHECK(b.data() == d.data());
+    zmq::const_buffer b2 = zmq::buffer(d, 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == d.data());
+}
+
+TEST_CASE("const_buffer creation array 2", "[buffer]")
+{
+    std::array<const BT, 10> d = {{}};
+    zmq::const_buffer b = zmq::buffer(d);
+    CHECK(b.size() == d.size() * sizeof(BT));
+    CHECK(b.data() == d.data());
+    zmq::const_buffer b2 = zmq::buffer(d, 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == d.data());
+}
+
+TEST_CASE("mutable_buffer creation vector", "[buffer]")
+{
+    std::vector<BT> d(10);
+    zmq::mutable_buffer b = zmq::buffer(d);
+    CHECK(b.size() == d.size() * sizeof(BT));
+    CHECK(b.data() == d.data());
+    zmq::mutable_buffer b2 = zmq::buffer(d, 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == d.data());
+    d.clear();
+    b = zmq::buffer(d);
+    CHECK(b.size() == 0);
+    CHECK(b.data() == nullptr);
+}
+
+TEST_CASE("const_buffer creation vector", "[buffer]")
+{
+    std::vector<BT> d(10);
+    zmq::const_buffer b = zmq::buffer(static_cast<const std::vector<BT>&>(d));
+    CHECK(b.size() == d.size() * sizeof(BT));
+    CHECK(b.data() == d.data());
+    zmq::const_buffer b2 = zmq::buffer(static_cast<const std::vector<BT>&>(d), 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == d.data());
+    d.clear();
+    b = zmq::buffer(static_cast<const std::vector<BT>&>(d));
+    CHECK(b.size() == 0);
+    CHECK(b.data() == nullptr);
+}
+
+TEST_CASE("const_buffer creation string", "[buffer]")
+{
+    const std::wstring d(10, L'a');
+    zmq::const_buffer b = zmq::buffer(d);
+    CHECK(b.size() == d.size() * sizeof(wchar_t));
+    CHECK(b.data() == d.data());
+    zmq::const_buffer b2 = zmq::buffer(d, 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == d.data());
+}
+
+TEST_CASE("mutable_buffer creation string", "[buffer]")
+{
+    std::wstring d(10, L'a');
+    zmq::mutable_buffer b = zmq::buffer(d);
+    CHECK(b.size() == d.size() * sizeof(wchar_t));
+    CHECK(b.data() == d.data());
+    zmq::mutable_buffer b2 = zmq::buffer(d, 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == d.data());
+}
+
+#ifdef ZMQ_CPP17
+TEST_CASE("const_buffer creation string_view", "[buffer]")
+{
+    std::wstring dstr(10, L'a');
+    std::wstring_view d = dstr;
+    zmq::const_buffer b = zmq::buffer(d);
+    CHECK(b.size() == d.size() * sizeof(wchar_t));
+    CHECK(b.data() == d.data());
+    zmq::const_buffer b2 = zmq::buffer(d, 4);
+    CHECK(b2.size() == 4);
+    CHECK(b2.data() == d.data());
+}
+#endif
+
+TEST_CASE("buffer of structs", "[buffer]")
+{
+    struct some_pod
+    {
+        int64_t val;
+        char arr[8];
+    };
+    struct some_non_pod
+    {
+        int64_t val;
+        char arr[8];
+        std::vector<int> s; // not trivially copyable
+    };
+    static_assert(zmq::detail::is_pod_like<some_pod>::value, "");
+    static_assert(!zmq::detail::is_pod_like<some_non_pod>::value, "");
+    std::array<some_pod, 1> d;
+    zmq::mutable_buffer b = zmq::buffer(d);
+    CHECK(b.size() == d.size() * sizeof(some_pod));
+    CHECK(b.data() == d.data());
+}
+
+#endif

--- a/tests/buffer.cpp
+++ b/tests/buffer.cpp
@@ -14,8 +14,8 @@ using BT = int16_t;
 
 TEST_CASE("buffer default ctor", "[buffer]")
 {
-    zmq::mutable_buffer mb;
-    zmq::const_buffer cb;
+    constexpr zmq::mutable_buffer mb;
+    constexpr zmq::const_buffer cb;
     CHECK(mb.size() == 0);
     CHECK(mb.data() == nullptr);
     CHECK(cb.size() == 0);
@@ -36,6 +36,13 @@ TEST_CASE("buffer data ctor", "[buffer]")
     CHECK(mb.data() == from_mut.data());
     const auto cmb = mb;
     static_assert(std::is_same<decltype(cmb.data()), void*>::value, "");
+
+    constexpr const void* cp = nullptr;
+    constexpr void* p = nullptr;
+    constexpr zmq::const_buffer cecb = zmq::buffer(p, 0);
+    constexpr zmq::mutable_buffer cemb = zmq::buffer(p, 0);
+    CHECK(cecb.data() == nullptr);
+    CHECK(cemb.data() == nullptr);
 }
 
 TEST_CASE("const_buffer operator+", "[buffer]")

--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -142,7 +142,7 @@ TEST_CASE("poller poll basic", "[poller]")
 {
     common_server_client_setup s;
 
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
 
     zmq::poller_t<int> poller;
     std::vector<zmq_poller_event_t> events{1};
@@ -220,7 +220,7 @@ TEST_CASE("poller poll client server", "[poller]")
     CHECK_NOTHROW(poller.add(s.server, ZMQ_POLLIN, s.server));
 
     // client sends message
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
 
     // wait for message and verify events
     std::vector<zmq_poller_event_t> events(1);
@@ -243,7 +243,7 @@ TEST_CASE("poller wait one return", "[poller]")
     CHECK_NOTHROW(poller.add(s.server, ZMQ_POLLIN, nullptr));
 
     // client sends message
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
 
     // wait for message and verify events
     std::vector<zmq_poller_event_t> events(1);
@@ -253,7 +253,7 @@ TEST_CASE("poller wait one return", "[poller]")
 TEST_CASE("poller wait on move constructed", "[poller]")
 {
     common_server_client_setup s;
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     zmq::poller_t<> a;
     CHECK_NOTHROW(a.add(s.server, ZMQ_POLLIN, nullptr));
     zmq::poller_t<> b{std::move(a)};
@@ -266,7 +266,7 @@ TEST_CASE("poller wait on move constructed", "[poller]")
 TEST_CASE("poller wait on move assigned", "[poller]")
 {
     common_server_client_setup s;
-    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+    CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     zmq::poller_t<> a;
     CHECK_NOTHROW(a.add(s.server, ZMQ_POLLIN, nullptr));
     zmq::poller_t<> b;
@@ -293,7 +293,7 @@ TEST_CASE("poller remove from handler", "[poller]")
     }
     // Clients send messages
     for (auto &s : setup_list) {
-        CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}));
+        CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     }
 
     // Wait for all servers to receive a message

--- a/tests/socket.cpp
+++ b/tests/socket.cpp
@@ -48,7 +48,7 @@ TEST_CASE("socket swap", "[socket]")
 }
 TEST_CASE("rass", "[socket]")
 {
-zmq::context_t ctx;
+    zmq::context_t ctx;
     zmq::socket_t sock(ctx, zmq::socket_type::push);
     sock.bind("inproc://test");
     const std::string m = "Hello, world";

--- a/tests/socket.cpp
+++ b/tests/socket.cpp
@@ -46,7 +46,27 @@ TEST_CASE("socket swap", "[socket]")
     using std::swap;
     swap(socket1, socket2);
 }
-TEST_CASE("rass", "[socket]")
+
+TEST_CASE("socket flags", "[socket]")
+{
+    CHECK((zmq::recv_flags::dontwait | zmq::recv_flags::none)
+          == static_cast<zmq::recv_flags>(ZMQ_DONTWAIT | 0));
+    CHECK((zmq::recv_flags::dontwait & zmq::recv_flags::none)
+          == static_cast<zmq::recv_flags>(ZMQ_DONTWAIT & 0));
+    CHECK((zmq::recv_flags::dontwait ^ zmq::recv_flags::none)
+          == static_cast<zmq::recv_flags>(ZMQ_DONTWAIT ^ 0));
+    CHECK(~zmq::recv_flags::dontwait == static_cast<zmq::recv_flags>(~ZMQ_DONTWAIT));
+
+    CHECK((zmq::send_flags::dontwait | zmq::send_flags::sndmore)
+          == static_cast<zmq::send_flags>(ZMQ_DONTWAIT | ZMQ_SNDMORE));
+    CHECK((zmq::send_flags::dontwait & zmq::send_flags::sndmore)
+          == static_cast<zmq::send_flags>(ZMQ_DONTWAIT & ZMQ_SNDMORE));
+    CHECK((zmq::send_flags::dontwait ^ zmq::send_flags::sndmore)
+          == static_cast<zmq::send_flags>(ZMQ_DONTWAIT ^ ZMQ_SNDMORE));
+    CHECK(~zmq::send_flags::dontwait == static_cast<zmq::send_flags>(~ZMQ_DONTWAIT));
+}
+
+TEST_CASE("socket readme example", "[socket]")
 {
     zmq::context_t ctx;
     zmq::socket_t sock(ctx, zmq::socket_type::push);

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -280,7 +280,7 @@ class message_t
     }
 
 #if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)
-    // this function is too greedy, must add
+    // TODO: this function is too greedy, must add
     // SFINAE for begin and end support.
     template<typename T>
     explicit message_t(const T &msg_) : message_t(std::begin(msg_), std::end(msg_))
@@ -654,7 +654,8 @@ enum class send_flags : int
 
 constexpr send_flags operator|(send_flags a, send_flags b) noexcept
 {
-    return static_cast<send_flags>(static_cast<int>(a) | static_cast<int>(b));
+    return static_cast<send_flags>(static_cast<std::underlying_type<send_flags>::type>(a)
+        | static_cast<<std::underlying_type<send_flags>::type>(b));
 }
 
 enum class recv_flags : int

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -645,6 +645,39 @@ struct recv_buffer_result
     }
 };
 
+namespace detail
+{
+template<class T>
+constexpr T enum_bit_or(T a, T b) noexcept
+{
+    static_assert(std::is_enum<T>::value, "must be enum");
+    using U = typename std::underlying_type<T>::type;
+    return static_cast<T>(static_cast<U>(a) | static_cast<U>(b));
+}
+template<class T>
+constexpr T enum_bit_and(T a, T b) noexcept
+{
+    static_assert(std::is_enum<T>::value, "must be enum");
+    using U = typename std::underlying_type<T>::type;
+    return static_cast<T>(static_cast<U>(a) & static_cast<U>(b));
+}
+template<class T>
+constexpr T enum_bit_xor(T a, T b) noexcept
+{
+    static_assert(std::is_enum<T>::value, "must be enum");
+    using U = typename std::underlying_type<T>::type;
+    return static_cast<T>(static_cast<U>(a) ^ static_cast<U>(b));
+}
+template<class T>
+constexpr T enum_bit_not(T a) noexcept
+{
+    static_assert(std::is_enum<T>::value, "must be enum");
+    using U = typename std::underlying_type<T>::type;
+    return static_cast<T>(~static_cast<U>(a));
+}
+} // namespace detail
+
+// partially satisfies named requirement BitmaskType
 enum class send_flags : int
 {
     none = 0,
@@ -654,10 +687,22 @@ enum class send_flags : int
 
 constexpr send_flags operator|(send_flags a, send_flags b) noexcept
 {
-    return static_cast<send_flags>(static_cast<std::underlying_type<send_flags>::type>(a)
-        | static_cast<<std::underlying_type<send_flags>::type>(b));
+    return detail::enum_bit_or(a, b);
+}
+constexpr send_flags operator&(send_flags a, send_flags b) noexcept
+{
+    return detail::enum_bit_and(a, b);
+}
+constexpr send_flags operator^(send_flags a, send_flags b) noexcept
+{
+    return detail::enum_bit_xor(a, b);
+}
+constexpr send_flags operator~(send_flags a) noexcept
+{
+    return detail::enum_bit_not(a);
 }
 
+// partially satisfies named requirement BitmaskType
 enum class recv_flags : int
 {
     none = 0,
@@ -666,8 +711,21 @@ enum class recv_flags : int
 
 constexpr recv_flags operator|(recv_flags a, recv_flags b) noexcept
 {
-    return static_cast<recv_flags>(static_cast<int>(a) | static_cast<int>(b));
+    return detail::enum_bit_or(a, b);
 }
+constexpr recv_flags operator&(recv_flags a, recv_flags b) noexcept
+{
+    return detail::enum_bit_and(a, b);
+}
+constexpr recv_flags operator^(recv_flags a, recv_flags b) noexcept
+{
+    return detail::enum_bit_xor(a, b);
+}
+constexpr recv_flags operator~(recv_flags a) noexcept
+{
+    return detail::enum_bit_not(a);
+}
+
 
 // mutable_buffer, const_buffer and buffer are based on
 // the Networking TS specification, draft:

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -734,14 +734,14 @@ constexpr recv_flags operator~(recv_flags a) noexcept
 class mutable_buffer
 {
   public:
-    mutable_buffer() noexcept : _data(nullptr), _size(0) {}
-    mutable_buffer(void *p, size_t n) noexcept : _data(p), _size(n)
+    constexpr mutable_buffer() noexcept : _data(nullptr), _size(0) {}
+    constexpr mutable_buffer(void *p, size_t n) noexcept : _data(p), _size(n)
     {
         assert(p != nullptr || n == 0);
     }
 
-    void *data() const noexcept { return _data; }
-    size_t size() const noexcept { return _size; }
+    constexpr void *data() const noexcept { return _data; }
+    constexpr size_t size() const noexcept { return _size; }
     mutable_buffer &operator+=(size_t n) noexcept
     {
         // (std::min) is a workaround for when a min macro is defined
@@ -769,16 +769,16 @@ inline mutable_buffer operator+(size_t n, const mutable_buffer &mb) noexcept
 class const_buffer
 {
   public:
-    const_buffer() noexcept : _data(nullptr), _size(0) {}
-    const_buffer(const void *p, size_t n) noexcept : _data(p), _size(n) {}
-    const_buffer(const mutable_buffer &mb) noexcept :
+    constexpr const_buffer() noexcept : _data(nullptr), _size(0) {}
+    constexpr const_buffer(const void *p, size_t n) noexcept : _data(p), _size(n) {}
+    constexpr const_buffer(const mutable_buffer &mb) noexcept :
         _data(mb.data()),
         _size(mb.size())
     {
     }
 
-    const void *data() const noexcept { return _data; }
-    size_t size() const noexcept { return _size; }
+    constexpr const void *data() const noexcept { return _data; }
+    constexpr size_t size() const noexcept { return _size; }
     const_buffer &operator+=(size_t n) noexcept
     {
         const auto shift = (std::min)(n, _size);
@@ -805,27 +805,27 @@ inline const_buffer operator+(size_t n, const const_buffer &cb) noexcept
 
 // buffer creation
 
-inline mutable_buffer buffer(void* p, size_t n) noexcept
+constexpr mutable_buffer buffer(void* p, size_t n) noexcept
 {
     return mutable_buffer(p, n);
 }
-inline const_buffer buffer(const void* p, size_t n) noexcept
+constexpr const_buffer buffer(const void* p, size_t n) noexcept
 {
     return const_buffer(p, n);
 }
-inline mutable_buffer buffer(const mutable_buffer& mb) noexcept
+constexpr mutable_buffer buffer(const mutable_buffer& mb) noexcept
 {
     return mb;
 }
-inline mutable_buffer buffer(const mutable_buffer& mb, size_t n) noexcept
+constexpr mutable_buffer buffer(const mutable_buffer& mb, size_t n) noexcept
 {
     return mutable_buffer(mb.data(), (std::min)(mb.size(), n));
 }
-inline const_buffer buffer(const const_buffer& cb) noexcept
+constexpr const_buffer buffer(const const_buffer& cb) noexcept
 {
     return cb;
 }
-inline const_buffer buffer(const const_buffer& cb, size_t n) noexcept
+constexpr const_buffer buffer(const const_buffer& cb, size_t n) noexcept
 {
     return const_buffer(cb.data(), (std::min)(cb.size(), n));
 }

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -131,7 +131,7 @@ class multipart_t
         while (more) {
             message_t message;
             #ifdef ZMQ_CPP11
-            if (!socket.recv(message, static_cast<recv_flags>(flags)).success)
+            if (!socket.recv(message, static_cast<recv_flags>(flags)))
                 return false;
             #else
             if (!socket.recv(&message, flags))
@@ -153,7 +153,7 @@ class multipart_t
             more = size() > 0;
             #ifdef ZMQ_CPP11
             if (!socket.send(message,
-                             static_cast<send_flags>((more ? ZMQ_SNDMORE : 0) | flags)).success)
+                             static_cast<send_flags>((more ? ZMQ_SNDMORE : 0) | flags)))
                 return false;
             #else
             if (!socket.send(message, (more ? ZMQ_SNDMORE : 0) | flags))

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -130,8 +130,13 @@ class multipart_t
         bool more = true;
         while (more) {
             message_t message;
+            #ifdef ZMQ_CPP11
+            if (!socket.recv(message, static_cast<recv_flags>(flags)).success)
+                return false;
+            #else
             if (!socket.recv(&message, flags))
                 return false;
+            #endif
             more = message.more();
             add(std::move(message));
         }
@@ -146,8 +151,14 @@ class multipart_t
         while (more) {
             message_t message = pop();
             more = size() > 0;
+            #ifdef ZMQ_CPP11
+            if (!socket.send(message,
+                             static_cast<send_flags>((more ? ZMQ_SNDMORE : 0) | flags)).success)
+                return false;
+            #else
             if (!socket.send(message, (more ? ZMQ_SNDMORE : 0) | flags))
                 return false;
+            #endif
         }
         clear();
         return true;


### PR DESCRIPTION
Solution: Add functions taking buffers and enum class flags

1. `enum class` flags `send_flags` and `recv_flags` instead of `int`s for safer `send` and `recv`.
2. Result structs `send_result`, `recv_result` and `recv_buffer_result` so that no information returned from libzmq is lost, removing ambiguity on EAGAIN (solving https://github.com/zeromq/cppzmq/issues/84 and https://github.com/zeromq/cppzmq/issues/61).
3. Buffer classes replacing `void*` and `size_t` pairs, based on `boost::asio::buffer` and the [Networking TS](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/n4771.pdf) `std::net::buffer` that will likely get added to C++23. This synchronizes the API of cppzmq with future standard C++ networking API (and current `boost::asio`), making it easier to use (and harder to misuse) and more familiar for newcomers. 

0MQ does not support sending or receiving buffer sequences (that would be more equivalent to multipart, which should be explicit anyway), so `send` and `recv` just take `const_buffer` and `mutable_buffer` (and not `ConstBufferSequence` and `MutableBufferSequence` as asio does). I envision `send_multipart` and `recv_multipart` taking ranges of `message_t`s or `buffer`s will make the library API more powerful, efficient and consistent, making the `multipart_t` container unnecessary.