### PR TITLE
make poller_t work with ancient gcc 4.8.1

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1868,7 +1868,11 @@ template<typename T = no_user_data> class poller_t
   public:
     using event_type = poller_event<T>;
 
-    poller_t() = default;
+    poller_t() : poller_ptr(zmq_poller_new())
+    {
+        if (!poller_ptr)
+            throw error_t();
+    }
 
     template<
       typename Dummy = void,
@@ -1931,13 +1935,7 @@ template<typename T = no_user_data> class poller_t
         }
     };
 
-    std::unique_ptr<void, destroy_poller_t> poller_ptr{
-      []() {
-          auto poller_new = zmq_poller_new();
-          if (poller_new)
-              return poller_new;
-          throw error_t();
-      }()};
+    std::unique_ptr<void, destroy_poller_t> poller_ptr;
 
     void add_impl(zmq::socket_ref socket, event_flags events, T *user_data)
     {


### PR DESCRIPTION
For some reason that I didn't get to the root cause of, gcc 4.8.1 (that I'm stuck with) does not like the initializer for `unique_ptr` implemented as a lambda:

```
third_party/zmqcpp/repo/zmq.hpp: In constructor 'zmq::poller_t<T>::poller_t() [with T = std::function<void(zmq::event_flags)>]':
third_party/zmqcpp/repo/zmq.hpp:1871:5: error: converting to 'std::unique_ptr<void, zmq::poller_t<std::function<void(zmq::event_flags)> >::destroy_poller_t>' from initializer list would use explicit constructor 'std::unique_ptr<_Ty, _Dx>::unique_ptr(std::unique_ptr<_Ty, _Dx>::pointer) [with _Ty = void; _Dx = zmq::poller_t<std::function<void(zmq::event_flags)> >::destroy_poller_t; std::unique_ptr<_Ty, _Dx>::pointer = void*]'
     poller_t() = default;
     ^
In file included from networking/ipc/ipc.cc:6:0:
third_party/zmqcpp/repo/zmq_addon.hpp: At global scope:
third_party/zmqcpp/repo/zmq_addon.hpp:447:40: note: synthesized method 'zmq::poller_t<T>::poller_t() [with T = std::function<void(zmq::event_flags)>]' first required here
     poller_t<handler_type> base_poller{};
                                        ^
In file included from ./networking/ipc/ipc.h:13:0,
                 from networking/ipc/ipc.cc:1:
third_party/zmqcpp/repo/zmq.hpp: In constructor 'zmq::poller_t<T>::poller_t() [with T = zmq::socket_t]':
third_party/zmqcpp/repo/zmq.hpp:1871:5: error: converting to 'std::unique_ptr<void, zmq::poller_t<zmq::socket_t>::destroy_poller_t>' from initializer list would use explicit constructor 'std::unique_ptr<_Ty, _Dx>::unique_ptr(std::unique_ptr<_Ty, _Dx>::pointer) [with _Ty = void; _Dx = zmq::poller_t<zmq::socket_t>::destroy_poller_t; std::unique_ptr<_Ty, _Dx>::pointer = void*]'
     poller_t() = default;
     ^
networking/ipc/ipc.cc: In member function 'void networking::ipc::Ipc::ThreadMain()':
networking/ipc/ipc.cc:313:36: note: synthesized method 'zmq::poller_t<T>::poller_t() [with T = zmq::socket_t]' first required here
   ::zmq::poller_t<::zmq::socket_t> poller;
                                    ^
```

This commit moves the initialization to constructor, and makes gcc happy.