### PR TITLE
Problem: C++11 partially supported on gcc 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,17 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
+    # GCC 4.9, draft disabled (default), latest libzmq (default)
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+
     # GCC 7, draft enabled, latest libzmq (default)
     - os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
           packages:
             - g++-4.9
       env:
-        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" CMAKE_CPP_STD=-DCMAKE_CXX_STANDARD=11
 
     # GCC 7, draft enabled, latest libzmq (default)
     - os: linux

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Supported platforms
  - Additional platforms that are known to work:
    - We have no current reports on additional platforms that are known to work yet. Please add your platform here. If CI can be provided for them with a cloud-based CI service working with GitHub, you are invited to add CI, and make it possible to be included in the list above.
  - Additional platforms that probably work:
-   - Any platform supported by libzmq that provides a sufficiently recent gcc (4.8.1 or newer) or clang (3.3 or newer)
+   - Any platform supported by libzmq that provides a sufficiently recent gcc (4.8.1 or newer) or clang (3.4.1 or newer)
    - Visual Studio 2012+ x86/x64
 
 Examples

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -39,7 +39,8 @@ cppzmq_build() {
     pushd .
     CMAKE_PREFIX_PATH=${LIBZMQ} \
     cmake -H. -B${CPPZMQ} -DENABLE_DRAFTS=${ENABLE_DRAFTS} \
-                          -DCOVERAGE=${COVERAGE}
+                          -DCOVERAGE=${COVERAGE} \
+                          ${CMAKE_CPP_STD:-}
     cmake --build ${CPPZMQ} -- -j${JOBS}
     popd
 }

--- a/tests/socket_ref.cpp
+++ b/tests/socket_ref.cpp
@@ -7,7 +7,7 @@ static_assert(std::is_nothrow_swappable_v<zmq::socket_ref>);
 #endif
 static_assert(sizeof(zmq::socket_ref) == sizeof(void *), "size mismatch");
 static_assert(alignof(zmq::socket_ref) == alignof(void *), "alignment mismatch");
-static_assert(std::is_trivially_copyable<zmq::socket_ref>::value,
+static_assert(ZMQ_IS_TRIVIALLY_COPYABLE(zmq::socket_ref),
               "needs to be trivially copyable");
 
 TEST_CASE("socket_ref default init", "[socket_ref]")

--- a/tests/utilities.cpp
+++ b/tests/utilities.cpp
@@ -1,7 +1,7 @@
 #include <catch.hpp>
 #include <zmq.hpp>
 
-#ifdef ZMQ_CPP11
+#if defined(ZMQ_CPP11) && !defined(ZMQ_CPP11_PARTIAL)
 
 namespace test_ns
 {
@@ -16,11 +16,11 @@ struct T_mr
 struct T_fr
 {
 };
-void *begin(const T_fr &) noexcept
+inline void *begin(const T_fr &) noexcept
 {
     return nullptr;
 }
-void *end(const T_fr &) noexcept
+inline void *end(const T_fr &) noexcept
 {
     return nullptr;
 }
@@ -29,11 +29,11 @@ struct T_mfr
     void *begin() const noexcept { return nullptr; }
     void *end() const noexcept { return nullptr; }
 };
-void *begin(const T_mfr &) noexcept
+inline void *begin(const T_mfr &) noexcept
 {
     return nullptr;
 }
-void *end(const T_mfr &) noexcept
+inline void *end(const T_mfr &) noexcept
 {
     return nullptr;
 }
@@ -50,11 +50,11 @@ struct T_assoc_ns_mr : std::exception
 struct T_assoc_ns_fr : std::exception
 {
 };
-void *begin(const T_assoc_ns_fr &) noexcept
+inline void *begin(const T_assoc_ns_fr &) noexcept
 {
     return nullptr;
 }
-void *end(const T_assoc_ns_fr &) noexcept
+inline void *end(const T_assoc_ns_fr &) noexcept
 {
     return nullptr;
 }
@@ -63,11 +63,11 @@ struct T_assoc_ns_mfr : std::exception
     void *begin() const noexcept { return nullptr; }
     void *end() const noexcept { return nullptr; }
 };
-void *begin(const T_assoc_ns_mfr &) noexcept
+inline void *begin(const T_assoc_ns_mfr &) noexcept
 {
     return nullptr;
 }
-void *end(const T_assoc_ns_mfr &) noexcept
+inline void *end(const T_assoc_ns_mfr &) noexcept
 {
     return nullptr;
 }

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -122,6 +122,14 @@
 #define ZMQ_DELETED_FUNCTION
 #endif
 
+#ifdef ZMQ_CPP11
+#if defined(__GNUC__) && __GNUC__ < 5
+#define ZMQ_IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
+#else
+#define ZMQ_IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
+#endif
+#endif
+
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(3, 3, 0)
 #define ZMQ_NEW_MONITOR_EVENT_LAYOUT
 #endif
@@ -331,7 +339,7 @@ class message_t
     template<class Range,
              typename = typename std::enable_if<
                detail::is_range<Range>::value
-               && std::is_trivially_copyable<detail::range_value_t<Range>>::value
+               && ZMQ_IS_TRIVIALLY_COPYABLE(detail::range_value_t<Range>)
                && !std::is_same<Range, message_t>::value>::type>
     explicit message_t(const Range &rng) :
         message_t(detail::ranges::begin(rng), detail::ranges::end(rng))
@@ -948,7 +956,7 @@ template<class T> struct is_pod_like
     // trivially copyable OR standard layout.
     // Here we decide to be conservative and require both.
     static constexpr bool value =
-      std::is_trivially_copyable<T>::value && std::is_standard_layout<T>::value;
+      ZMQ_IS_TRIVIALLY_COPYABLE(T) && std::is_standard_layout<T>::value;
 };
 
 template<class C> constexpr auto seq_size(const C &c) noexcept -> decltype(c.size())

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -122,8 +122,12 @@
 #define ZMQ_DELETED_FUNCTION
 #endif
 
+#if defined(ZMQ_CPP11) && defined(__GNUC__) && __GNUC__ < 5
+#define ZMQ_CPP11_PARTIAL
+#endif
+
 #ifdef ZMQ_CPP11
-#if defined(__GNUC__) && __GNUC__ < 5
+#ifdef ZMQ_CPP11_PARTIAL
 #define ZMQ_IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
 #else
 #define ZMQ_IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
@@ -335,7 +339,7 @@ class message_t
             throw error_t();
     }
 
-#ifdef ZMQ_CPP11
+#if defined(ZMQ_CPP11) && !defined(ZMQ_CPP11_PARTIAL)
     template<class Range,
              typename = typename std::enable_if<
                detail::is_range<Range>::value


### PR DESCRIPTION
Solution: Use intrinsic instead of std::is_trivially_copyable for gcc versions older than 5.