### PR TITLE
Problem: Sending string literals is awkward

### DIFF
--- a/tests/buffer.cpp
+++ b/tests/buffer.cpp
@@ -244,7 +244,7 @@ TEST_CASE("const_buffer creation with str_buffer", "[buffer]")
     CHECK(b.data() == static_cast<const wchar_t*>(wd));
 
     zmq::const_buffer b2_null = zmq::buffer("hello");
-    zmq::const_buffer b2 = zmq::str_buffer("hello");
+    constexpr zmq::const_buffer b2 = zmq::str_buffer("hello");
     CHECK(b2_null.size() == 6);
     CHECK(b2.size() == 5);
     CHECK(std::string(static_cast<const char*>(b2.data()), b2.size()) == "hello");

--- a/tests/buffer.cpp
+++ b/tests/buffer.cpp
@@ -236,6 +236,20 @@ TEST_CASE("const_buffer creation string_view", "[buffer]")
 }
 #endif
 
+TEST_CASE("const_buffer creation with str_buffer", "[buffer]")
+{
+    const wchar_t wd[10] = {};
+    zmq::const_buffer b = zmq::str_buffer(wd);
+    CHECK(b.size() == 9 * sizeof(wchar_t));
+    CHECK(b.data() == static_cast<const wchar_t*>(wd));
+
+    zmq::const_buffer b2_null = zmq::buffer("hello");
+    zmq::const_buffer b2 = zmq::str_buffer("hello");
+    CHECK(b2_null.size() == 6);
+    CHECK(b2.size() == 5);
+    CHECK(std::string(static_cast<const char*>(b2.data()), b2.size()) == "hello");
+}
+
 TEST_CASE("buffer of structs", "[buffer]")
 {
     struct some_pod

--- a/tests/buffer.cpp
+++ b/tests/buffer.cpp
@@ -250,6 +250,38 @@ TEST_CASE("const_buffer creation with str_buffer", "[buffer]")
     CHECK(std::string(static_cast<const char*>(b2.data()), b2.size()) == "hello");
 }
 
+TEST_CASE("const_buffer creation with zbuf string literal char", "[buffer]")
+{
+    using namespace zmq::literals;
+    constexpr zmq::const_buffer b = "hello"_zbuf;
+    CHECK(b.size() == 5);
+    CHECK(std::memcmp(b.data(), "hello", b.size()) == 0);
+}
+
+TEST_CASE("const_buffer creation with zbuf string literal wchar_t", "[buffer]")
+{
+    using namespace zmq::literals;
+    constexpr zmq::const_buffer b = L"hello"_zbuf;
+    CHECK(b.size() == 5 * sizeof(wchar_t));
+    CHECK(std::memcmp(b.data(), L"hello", b.size()) == 0);
+}
+
+TEST_CASE("const_buffer creation with zbuf string literal char16_t", "[buffer]")
+{
+    using namespace zmq::literals;
+    constexpr zmq::const_buffer b = u"hello"_zbuf;
+    CHECK(b.size() == 5 * sizeof(char16_t));
+    CHECK(std::memcmp(b.data(), u"hello", b.size()) == 0);
+}
+
+TEST_CASE("const_buffer creation with zbuf string literal char32_t", "[buffer]")
+{
+    using namespace zmq::literals;
+    constexpr zmq::const_buffer b = U"hello"_zbuf;
+    CHECK(b.size() == 5 * sizeof(char32_t));
+    CHECK(std::memcmp(b.data(), U"hello", b.size()) == 0);
+}
+
 TEST_CASE("buffer of structs", "[buffer]")
 {
     struct some_pod

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1110,6 +1110,19 @@ const_buffer buffer(std::basic_string_view<T, Traits> data, size_t n_bytes) noex
 }
 #endif
 
+// Buffer for a string literal (null terminated)
+// where the buffer size excludes the terminating character.
+// Equivalent to zmq::buffer(std::string_view("...")).
+template<class Char, size_t N>
+const_buffer str_buffer(const Char (&data)[N]) noexcept
+{
+    static_assert(detail::is_pod_like<Char>::value, "Char must be POD");
+    static_assert(N > 0, "N > 0");
+    assert(data[N - 1] == Char{0});
+    return const_buffer(N == 1 ? nullptr : static_cast<const Char*>(data), 
+                        (N - 1) * sizeof(Char));
+}
+
 #endif // ZMQ_CPP11
 
 namespace detail

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1124,6 +1124,26 @@ constexpr const_buffer str_buffer(const Char (&data)[N]) noexcept
                         (N - 1) * sizeof(Char));
 }
 
+namespace literals
+{
+    constexpr const_buffer operator"" _zbuf(const char* str, size_t len) noexcept
+    {
+        return const_buffer(str, len * sizeof(char));
+    }
+    constexpr const_buffer operator"" _zbuf(const wchar_t* str, size_t len) noexcept
+    {
+        return const_buffer(str, len * sizeof(wchar_t));
+    }
+    constexpr const_buffer operator"" _zbuf(const char16_t* str, size_t len) noexcept
+    {
+        return const_buffer(str, len * sizeof(char16_t));
+    }
+    constexpr const_buffer operator"" _zbuf(const char32_t* str, size_t len) noexcept
+    {
+        return const_buffer(str, len * sizeof(char32_t));
+    }
+}
+
 #endif // ZMQ_CPP11
 
 namespace detail

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1114,12 +1114,13 @@ const_buffer buffer(std::basic_string_view<T, Traits> data, size_t n_bytes) noex
 // where the buffer size excludes the terminating character.
 // Equivalent to zmq::buffer(std::string_view("...")).
 template<class Char, size_t N>
-const_buffer str_buffer(const Char (&data)[N]) noexcept
+constexpr const_buffer str_buffer(const Char (&data)[N]) noexcept
 {
     static_assert(detail::is_pod_like<Char>::value, "Char must be POD");
-    static_assert(N > 0, "N > 0");
+#ifdef ZMQ_CPP14
     assert(data[N - 1] == Char{0});
-    return const_buffer(N == 1 ? nullptr : static_cast<const Char*>(data), 
+#endif
+    return const_buffer(static_cast<const Char*>(data), 
                         (N - 1) * sizeof(Char));
 }
 


### PR DESCRIPTION
Solution: A function str_buffer specifically for
creating buffers for null terminated string literals.

Before
```C++
s.send(zmq::buffer(std::string_view{"ping"})); // C++17
auto s = "ping";
s.send(zmq::buffer(s, std::strlen(s))); // C++11
```
After
```C++
s.send(zmq::str_buffer("ping"));
```