### PR TITLE
Added the option not to install the package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ include (DetectCPPZMQVersion)
 
 project(cppzmq VERSION ${DETECTED_CPPZMQ_VERSION})
 
+option(CPPZMQ_ENABLE_INSTALL "Generate the install target" ON )
+
 find_package(ZeroMQ QUIET)
 
 # libzmq autotools install: fallback to pkg-config
@@ -49,41 +51,43 @@ foreach (target cppzmq cppzmq-static)
                                                  $<INSTALL_INTERFACE:include>)
 endforeach()
 
-target_link_libraries(cppzmq INTERFACE libzmq)
-target_link_libraries(cppzmq-static INTERFACE libzmq-static)
+target_link_libraries(cppzmq INTERFACE ${ZeroMQ_LIBRARY} )
+target_link_libraries(cppzmq-static INTERFACE ${ZeroMQ_STATIC_LIBRARY})
 
-include(GNUInstallDirs)
-include(CMakePackageConfigHelpers)
+if(CPPZMQ_ENABLE_INSTALL)
+	include(GNUInstallDirs)
+	include(CMakePackageConfigHelpers)
 
-install(TARGETS cppzmq cppzmq-static
-        EXPORT ${PROJECT_NAME}-targets)
+	install(TARGETS cppzmq cppzmq-static
+        	EXPORT ${PROJECT_NAME}-targets)
 
-install(FILES ${CPPZMQ_HEADERS}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+	install(FILES ${CPPZMQ_HEADERS}
+        	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
-set(CPPZMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for cppzmqConfig.cmake")
+	# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
+	set(CPPZMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for cppzmqConfig.cmake")
 
-configure_file(libzmq-pkg-config/FindZeroMQ.cmake
-               libzmq-pkg-config/FindZeroMQ.cmake
-               COPYONLY)
+	configure_file(libzmq-pkg-config/FindZeroMQ.cmake
+    	           libzmq-pkg-config/FindZeroMQ.cmake
+        	       COPYONLY)
 
-export(EXPORT ${PROJECT_NAME}-targets
-     FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
-configure_package_config_file(${PROJECT_NAME}Config.cmake.in
-                              "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-                              INSTALL_DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
-write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-                                 VERSION ${CPPZMQ_VERSION}
-                                 COMPATIBILITY AnyNewerVersion)
-install(EXPORT ${PROJECT_NAME}-targets
-        FILE ${PROJECT_NAME}Targets.cmake
-        DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-              DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
-              DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR}/libzmq-pkg-config)
+	export(EXPORT ${PROJECT_NAME}-targets
+    	   FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
+	configure_package_config_file(${PROJECT_NAME}Config.cmake.in
+    	                          "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+        	                      INSTALL_DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
+	write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    	                             VERSION ${CPPZMQ_VERSION}
+        	                         COMPATIBILITY AnyNewerVersion)
+	install(EXPORT ${PROJECT_NAME}-targets
+    	    FILE ${PROJECT_NAME}Targets.cmake
+        	DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+            DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
+            DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR}/libzmq-pkg-config)              
+endif()
 
 option(CPPZMQ_BUILD_TESTS "Whether or not to build the tests" ON)
 


### PR DESCRIPTION
This can be useful to use cppzmq directly as a subproject. Allows to import this repository as a whole as a subtree or submodule and use the generated targets without exporting it in the main project install target