### PR TITLE
Switch zmq_addon.hpp to include zmq.hpp using "zmq.hpp" instead

### DIFF
--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -24,7 +24,7 @@
 #ifndef __ZMQ_ADDON_HPP_INCLUDED__
 #define __ZMQ_ADDON_HPP_INCLUDED__
 
-#include <zmq.hpp>
+#include "zmq.hpp"
 
 #include <deque>
 #include <iomanip>


### PR DESCRIPTION
Switch zmq_addon.hpp to include zmq.hpp using "zmq.hpp" instead of <zmq.hpp>  This allows it to look in the current directory for the header file.  This enables the ability to have cppzmq as a subdirectory of an included folder vs needing to have the cppzmq on the include search path, and makes it less likely the wrong version would get included if more than one zmq.hpp header happened to be available.

This is a second PR based on conversation from #355