### PR TITLE
Problem: Handling multipart messages is complex

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ Supported platforms
 
 Examples
 ========
-This example requires at least C++11.
+These examples requires at least C++11.
 ```c++
-#include <string>
 #include <zmq.hpp>
 
 int main()
@@ -52,6 +51,36 @@ int main()
     zmq::socket_t sock(ctx, zmq::socket_type::push);
     sock.bind("inproc://test");
     sock.send(zmq::str_buffer("Hello, world"), zmq::send_flags::dontwait);
+}
+```
+This a more complex example where we send and receive multi-part messages.
+```c++
+#include <iostream>
+#include <zmq_addon.hpp>
+
+int main()
+{
+    zmq::context_t ctx;
+    zmq::socket_t sock1(ctx, zmq::socket_type::pair);
+    zmq::socket_t sock2(ctx, zmq::socket_type::pair);
+    sock1.bind("inproc://test");
+    sock2.connect("inproc://test");
+
+    std::array<zmq::const_buffer, 2> send_msgs = {
+        zmq::str_buffer("foo"),
+        zmq::str_buffer("bar!")
+    };
+    if (!zmq::send_multipart(sock1, send_msgs))
+        return 1;
+
+    std::vector<zmq::message_t> recv_msgs;
+    const auto ret = zmq::recv_multipart(
+        sock2, std::back_inserter(recv_msgs));
+    if (!ret)
+        return 1;
+    std::cout << "Got " << *ret
+              << " messages" << std::endl;
+    return 0;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Supported platforms
 
 Examples
 ========
-These examples requires at least C++11.
+These examples require at least C++11.
 ```c++
 #include <zmq.hpp>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,8 @@ add_executable(
     poller.cpp
     active_poller.cpp
     multipart.cpp
+    recv_multipart.cpp
+    send_multipart.cpp
     monitor.cpp
     utilities.cpp
 )

--- a/tests/recv_multipart.cpp
+++ b/tests/recv_multipart.cpp
@@ -1,0 +1,60 @@
+#include <catch.hpp>
+#include <zmq_addon.hpp>
+
+#ifdef ZMQ_CPP11
+
+TEST_CASE("recv_multipart test", "[recv_multipart]")
+{
+    zmq::context_t context(1);
+    zmq::socket_t output(context, ZMQ_PAIR);
+    zmq::socket_t input(context, ZMQ_PAIR);
+    output.bind("inproc://multipart.test");
+    input.connect("inproc://multipart.test");
+
+    SECTION("send 1 message")
+    {
+        input.send(zmq::str_buffer("hello"));
+
+        std::vector<zmq::message_t> msgs;
+        auto ret = zmq::recv_multipart(output, std::back_inserter(msgs));
+        REQUIRE(ret);
+        CHECK(*ret == 1);
+        REQUIRE(msgs.size() == 1);
+        CHECK(msgs[0].size() == 5);
+    }
+    SECTION("send 2 messages")
+    {
+        input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
+        input.send(zmq::str_buffer("world!"));
+
+        std::vector<zmq::message_t> msgs;
+        auto ret = zmq::recv_multipart(output, std::back_inserter(msgs));
+        REQUIRE(ret);
+        CHECK(*ret == 2);
+        REQUIRE(msgs.size() == 2);
+        CHECK(msgs[0].size() == 5);
+        CHECK(msgs[1].size() == 6);
+    }
+    SECTION("send no messages, dontwait")
+    {
+        std::vector<zmq::message_t> msgs;
+        auto ret = zmq::recv_multipart(output, std::back_inserter(msgs), zmq::recv_flags::dontwait);
+        CHECK_FALSE(ret);
+        REQUIRE(msgs.size() == 0);
+    }
+    SECTION("send 1 partial message, dontwait")
+    {
+        input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
+
+        std::vector<zmq::message_t> msgs;
+        auto ret = zmq::recv_multipart(output, std::back_inserter(msgs), zmq::recv_flags::dontwait);
+        CHECK_FALSE(ret);
+        REQUIRE(msgs.size() == 0);
+    }
+    SECTION("recv with invalid socket")
+    {
+        std::vector<zmq::message_t> msgs;
+        CHECK_THROWS_AS(zmq::recv_multipart(zmq::socket_ref(), std::back_inserter(msgs)), const zmq::error_t &);
+    }
+}
+#endif

--- a/tests/recv_multipart.cpp
+++ b/tests/recv_multipart.cpp
@@ -1,7 +1,7 @@
+#ifdef ZMQ_CPP11
+
 #include <catch.hpp>
 #include <zmq_addon.hpp>
-
-#ifdef ZMQ_CPP11
 
 TEST_CASE("recv_multipart test", "[recv_multipart]")
 {

--- a/tests/send_multipart.cpp
+++ b/tests/send_multipart.cpp
@@ -1,8 +1,8 @@
+#ifdef ZMQ_CPP11
+
 #include <forward_list>
 #include <catch.hpp>
 #include <zmq_addon.hpp>
-
-#ifdef ZMQ_CPP11
 
 TEST_CASE("send_multipart test", "[send_multipart]")
 {
@@ -88,7 +88,6 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         auto iret = zmq::send_multipart(push, imsgs, zmq::send_flags::dontwait);
         REQUIRE_FALSE(iret);
     }
-    // TODO send with EAGAIN
     SECTION("send, misc. containers")
     {
         std::vector<zmq::message_t> msgs_vec;

--- a/tests/send_multipart.cpp
+++ b/tests/send_multipart.cpp
@@ -1,0 +1,125 @@
+#include <forward_list>
+#include <catch.hpp>
+#include <zmq_addon.hpp>
+
+#ifdef ZMQ_CPP11
+
+TEST_CASE("send_multipart test", "[send_multipart]")
+{
+    zmq::context_t context(1);
+    zmq::socket_t output(context, ZMQ_PAIR);
+    zmq::socket_t input(context, ZMQ_PAIR);
+    output.bind("inproc://multipart.test");
+    input.connect("inproc://multipart.test");
+
+    SECTION("send 0 messages")
+    {
+        std::vector<zmq::message_t> imsgs;
+        auto iret = zmq::send_multipart(input, imsgs);
+        REQUIRE(iret);
+        CHECK(*iret == 0);
+    }
+    SECTION("send 1 message")
+    {
+        std::array<zmq::message_t, 1> imsgs = {zmq::message_t(3)};
+        auto iret = zmq::send_multipart(input, imsgs);
+        REQUIRE(iret);
+        CHECK(*iret == 1);
+
+        std::vector<zmq::message_t> omsgs;
+        auto oret = zmq::recv_multipart(output, std::back_inserter(omsgs));
+        REQUIRE(oret);
+        CHECK(*oret == 1);
+        REQUIRE(omsgs.size() == 1);
+        CHECK(omsgs[0].size() == 3);
+    }
+    SECTION("send 2 messages")
+    {
+        std::array<zmq::message_t, 2> imsgs = {zmq::message_t(3), zmq::message_t(4)};
+        auto iret = zmq::send_multipart(input, imsgs);
+        REQUIRE(iret);
+        CHECK(*iret == 2);
+
+        std::vector<zmq::message_t> omsgs;
+        auto oret = zmq::recv_multipart(output, std::back_inserter(omsgs));
+        REQUIRE(oret);
+        CHECK(*oret == 2);
+        REQUIRE(omsgs.size() == 2);
+        CHECK(omsgs[0].size() == 3);
+        CHECK(omsgs[1].size() == 4);
+    }
+    SECTION("send 2 messages, const_buffer")
+    {
+        std::array<zmq::const_buffer, 2> imsgs = {zmq::str_buffer("foo"), zmq::str_buffer("bar!")};
+        auto iret = zmq::send_multipart(input, imsgs);
+        REQUIRE(iret);
+        CHECK(*iret == 2);
+
+        std::vector<zmq::message_t> omsgs;
+        auto oret = zmq::recv_multipart(output, std::back_inserter(omsgs));
+        REQUIRE(oret);
+        CHECK(*oret == 2);
+        REQUIRE(omsgs.size() == 2);
+        CHECK(omsgs[0].size() == 3);
+        CHECK(omsgs[1].size() == 4);
+    }
+    SECTION("send 2 messages, mutable_buffer")
+    {
+        char buf[4] = {};
+        std::array<zmq::mutable_buffer, 2> imsgs = {zmq::buffer(buf, 3), zmq::buffer(buf)};
+        auto iret = zmq::send_multipart(input, imsgs);
+        REQUIRE(iret);
+        CHECK(*iret == 2);
+
+        std::vector<zmq::message_t> omsgs;
+        auto oret = zmq::recv_multipart(output, std::back_inserter(omsgs));
+        REQUIRE(oret);
+        CHECK(*oret == 2);
+        REQUIRE(omsgs.size() == 2);
+        CHECK(omsgs[0].size() == 3);
+        CHECK(omsgs[1].size() == 4);
+    }
+    SECTION("send 2 messages, dontwait")
+    {
+        zmq::socket_t push(context, ZMQ_PUSH);
+        push.bind("inproc://multipart.test.push");
+        
+        std::array<zmq::message_t, 2> imsgs = {zmq::message_t(3), zmq::message_t(4)};
+        auto iret = zmq::send_multipart(push, imsgs, zmq::send_flags::dontwait);
+        REQUIRE_FALSE(iret);
+    }
+    // TODO send with EAGAIN
+    SECTION("send, misc. containers")
+    {
+        std::vector<zmq::message_t> msgs_vec;
+        msgs_vec.emplace_back(3);
+        msgs_vec.emplace_back(4);
+        auto iret = zmq::send_multipart(input, msgs_vec);
+        REQUIRE(iret);
+        CHECK(*iret == 2);
+
+        std::forward_list<zmq::message_t> msgs_list;
+        msgs_list.emplace_front(4);
+        msgs_list.emplace_front(3);
+        iret = zmq::send_multipart(input, msgs_list);
+        REQUIRE(iret);
+        CHECK(*iret == 2);
+
+        // init. list
+        const auto msgs_il = {zmq::str_buffer("foo"), zmq::str_buffer("bar!")};
+        iret = zmq::send_multipart(input, msgs_il);
+        REQUIRE(iret);
+        CHECK(*iret == 2);
+        // rvalue
+        iret = zmq::send_multipart(input, 
+            std::initializer_list<zmq::const_buffer>{zmq::str_buffer("foo"), zmq::str_buffer("bar!")});
+        REQUIRE(iret);
+        CHECK(*iret == 2);
+    }
+    SECTION("send with invalid socket")
+    {
+        std::vector<zmq::message_t> msgs(1);
+        CHECK_THROWS_AS(zmq::send_multipart(zmq::socket_ref(), msgs), const zmq::error_t &);
+    }
+}
+#endif

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -971,6 +971,15 @@ inline const_buffer buffer(const const_buffer& cb, size_t n) noexcept
 
 namespace detail
 {
+
+template<class T>
+struct is_buffer
+{
+    static constexpr bool value = 
+        std::is_same<T, const_buffer>::value ||
+        std::is_same<T, mutable_buffer>::value;
+};
+
 template<class T> struct is_pod_like
 {
     // NOTE: The networking draft N4771 section 16.11 requires

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -96,8 +96,10 @@ template<class Range,
 detail::send_result_t send_multipart(socket_ref s, Range&& msgs,
                                        send_flags flags = send_flags::none)
 {
-    auto it = msgs.begin();
-    const auto end_it = msgs.end();
+    using std::begin;
+    using std::end;
+    auto it = begin(msgs);
+    const auto end_it = end(msgs);
     size_t msg_count = 0;
     while (it != end_it)
     {
@@ -106,7 +108,7 @@ detail::send_result_t send_multipart(socket_ref s, Range&& msgs,
         if (!s.send(*it, msg_flags))
         {
             // zmq ensures atomic delivery of messages
-            assert(it == msgs.begin());
+            assert(it == begin(msgs));
             return {};
         }
         ++msg_count;


### PR DESCRIPTION
Solution: Add generic algorithms for sending and receiving multipart
messages.

A possible future extension to these functions is a `recv_multipart_n` where for writing to fixed size containers.