### PR TITLE
Problem: Move assigned objects still alive

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -644,6 +644,7 @@ class context_t
     context_t(context_t &&rhs) ZMQ_NOTHROW : ptr(rhs.ptr) { rhs.ptr = ZMQ_NULLPTR; }
     context_t &operator=(context_t &&rhs) ZMQ_NOTHROW
     {
+        close();
         std::swap(ptr, rhs.ptr);
         return *this;
     }
@@ -1566,6 +1567,7 @@ class socket_t : public detail::socket_base
     }
     socket_t &operator=(socket_t &&rhs) ZMQ_NOTHROW
     {
+        close();
         std::swap(_handle, rhs._handle);
         return *this;
     }


### PR DESCRIPTION
Solution: Close context/socket if move assigned to

The problem is the following
```c++
void f(socket_t& a, socket_t& b)
{
  a = std::move(b);
}
```
Currently after calling this function `b` will be the socket that used to be `a`, which I think is surprising. After this PR `b` will be an "empty" socket.
Since this is only changing the value of a moved-from objects it should not break user code, unless they are doing something they shouldn't be doing.