### PR TITLE
Problem: Invalid 32bit issues when using Conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,13 @@ export(EXPORT ${PROJECT_NAME}-targets
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
                               INSTALL_DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
-# workaround until ARCH_INDEPENDENT flag can be used with cmake 3.14
+# Workaround until ARCH_INDEPENDENT flag can be used with cmake 3.14.
+# The ConigVersion.cmake file contains checks for the architecture is was
+# generated on, which can cause problems for header only libraries
+# used with e.g. the Conan package manager. Since it is header only we
+# can/should omit those checks.
 set(CPPZMQ_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
-unset(CMAKE_SIZEOF_VOID_P)
+set(CMAKE_SIZEOF_VOID_P "") # a simple unset is not sufficient
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
                                  VERSION ${CPPZMQ_VERSION}
                                  COMPATIBILITY AnyNewerVersion)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,14 @@ export(EXPORT ${PROJECT_NAME}-targets
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
                               INSTALL_DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})
+# workaround until ARCH_INDEPENDENT flag can be used with cmake 3.14
+set(CPPZMQ_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
+unset(CMAKE_SIZEOF_VOID_P)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
                                  VERSION ${CPPZMQ_VERSION}
                                  COMPATIBILITY AnyNewerVersion)
+set(CMAKE_SIZEOF_VOID_P ${CPPZMQ_SIZEOF_VOID_P})
+
 install(EXPORT ${PROJECT_NAME}-targets
         FILE ${PROJECT_NAME}Targets.cmake
         DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR})


### PR DESCRIPTION
Solution: Remove architechture checks from cmake version file

Since this is a header only library there is no need to check for 32 vs 64bits.

See similar problem: https://github.com/onqtam/doctest/pull/225