### PR TITLE
Problem: shutdown() missing for context_t

### DIFF
--- a/tests/context.cpp
+++ b/tests/context.cpp
@@ -63,15 +63,4 @@ TEST_CASE("context - use socket after shutdown", "[context]")
         REQUIRE(e.num() == ETERM);
     }
 }
-
-TEST_CASE("context - create socket after shutdown", "[context]")
-{
-    zmq::context_t context;
-    context.shutdown();
-    // sockets created after shutdown dont return ETERM
-    zmq::socket_t sock(context, zmq::socket_type::rep);
-    sock.connect("inproc://test");
-    zmq::message_t msg;
-    sock.recv(msg, zmq::recv_flags::dontwait);
-}
 #endif

--- a/tests/context.cpp
+++ b/tests/context.cpp
@@ -27,10 +27,9 @@ TEST_CASE("context shutdown", "[context]")
     CHECK(NULL == (void *) context);
 }
 
-TEST_CASE("context shutdown often", "[context]")
+TEST_CASE("context shutdown again", "[context]")
 {
     zmq::context_t context;
-    context.shutdown();
     context.shutdown();
     context.shutdown();
     CHECK(NULL != (void *) context);

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -694,9 +694,7 @@ class context_t
 
     // Shutdown context in preparation for termination (close()).
     // Causes all blocking socket operations and any further
-    // operations to return with ETERM.
-    // Operation on sockets constructed after
-    // this call might not return with ETERM.
+    // socket operations to return with ETERM.
     void shutdown() ZMQ_NOTHROW
     {
         if (ptr == ZMQ_NULLPTR)

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -677,6 +677,7 @@ class context_t
 
     ~context_t() ZMQ_NOTHROW { close(); }
 
+    // Terminates context (see also shutdown()).
     void close() ZMQ_NOTHROW
     {
         if (ptr == ZMQ_NULLPTR)
@@ -689,6 +690,19 @@ class context_t
 
         ZMQ_ASSERT(rc == 0);
         ptr = ZMQ_NULLPTR;
+    }
+
+    // Shutdown context in preparation for termination (close()).
+    // Causes all blocking socket operations and any further
+    // operations to return with ETERM.
+    // Operation on sockets constructed after
+    // this call will however NOT return with ETERM.
+    void shutdown() ZMQ_NOTHROW
+    {
+        if (ptr == ZMQ_NULLPTR)
+            return;
+        int rc = zmq_ctx_shutdown(ptr);
+        ZMQ_ASSERT(rc == 0);
     }
 
     //  Be careful with this, it's probably only useful for

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -696,7 +696,7 @@ class context_t
     // Causes all blocking socket operations and any further
     // operations to return with ETERM.
     // Operation on sockets constructed after
-    // this call will however NOT return with ETERM.
+    // this call might not return with ETERM.
     void shutdown() ZMQ_NOTHROW
     {
         if (ptr == ZMQ_NULLPTR)


### PR DESCRIPTION
Solution: Add shutdown(). This function is required
for clean termination of the zmq context in multi-threaded
applications where sockets are used in threads. In particular
if blocking operation are used and if sockets can be created
at any time.