### PR TITLE
Problem: Terminating ctx safely is hard

### DIFF
--- a/tests/context.cpp
+++ b/tests/context.cpp
@@ -85,8 +85,7 @@ TEST_CASE("context - create socket after shutdown - shutdown_guard", "[context]"
         zmq::socket_t sock(context, zmq::socket_type::rep);
         sock.connect("inproc://test");
         zmq::message_t msg;
-        sock.recv(msg, zmq::recv_flags::dontwait);
-        REQUIRE(false);
+        sock.recv(msg); // blocks until shutdown
     }
     catch (const zmq::error_t& e)
     {
@@ -105,18 +104,15 @@ TEST_CASE("context - create socket in thread after shutdown - shutdown_guard", "
             zmq::socket_t sock(context, zmq::socket_type::rep);
             sock.connect("inproc://test");
             zmq::message_t msg;
-            sock.recv(msg, zmq::recv_flags::dontwait);
-            REQUIRE(false);
+            sock.recv(msg); // blocks until shutdown
         }
         catch (const zmq::error_t& e)
         {
             REQUIRE(e.num() == ETERM);
         }
     });
-    {
-        zmq::shutdown_guard sg{context};
-        thread.join();
-    }
-    context.close();
+
+    zmq::shutdown_guard sg{context};
+    thread.join();
 }
 #endif

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -677,6 +677,7 @@ class context_t
 
     ~context_t() ZMQ_NOTHROW { close(); }
 
+    // Terminates context (see also shutdown()).
     void close() ZMQ_NOTHROW
     {
         if (ptr == ZMQ_NULLPTR)
@@ -689,6 +690,19 @@ class context_t
 
         ZMQ_ASSERT(rc == 0);
         ptr = ZMQ_NULLPTR;
+    }
+
+    // Shutdown context in preparation for termination (close()).
+    // Causes all blocking socket operations and any further
+    // operations to return with ETERM.
+    // Operation on sockets constructed after
+    // this call will however NOT return with ETERM.
+    void shutdown() ZMQ_NOTHROW
+    {
+        if (ptr == ZMQ_NULLPTR)
+            return;
+        int rc = zmq_ctx_shutdown(ptr);
+        ZMQ_ASSERT(rc == 0);
     }
 
     //  Be careful with this, it's probably only useful for


### PR DESCRIPTION
Solution: A shudown_guard running in a thread
that calls shutdown() on a context until
notified to stop. This class makes terminating
a context in multi-threaded code safe and easy.