### PR TITLE
Reformat all files with clang-format

### DIFF
--- a/tests/active_poller.cpp
+++ b/tests/active_poller.cpp
@@ -14,9 +14,9 @@ TEST_CASE("create destroy", "[active_poller]")
 }
 
 static_assert(!std::is_copy_constructible<zmq::active_poller_t>::value,
-              "active_active_poller_t should not be copy-constructible");
+    "active_active_poller_t should not be copy-constructible");
 static_assert(!std::is_copy_assignable<zmq::active_poller_t>::value,
-              "active_active_poller_t should not be copy-assignable");
+    "active_active_poller_t should not be copy-assignable");
 
 TEST_CASE("move construct empty", "[active_poller]")
 {
@@ -47,7 +47,9 @@ TEST_CASE("move construct non empty", "[active_poller]")
     zmq::socket_t socket{context, zmq::socket_type::router};
 
     zmq::active_poller_t a;
-    a.add(socket, zmq::event_flags::pollin, [](zmq::event_flags) {});
+    a.add(socket, zmq::event_flags::pollin, [](zmq::event_flags)
+    {
+    });
     CHECK_FALSE(a.empty());
     CHECK(1u == a.size());
     zmq::active_poller_t b = std::move(a);
@@ -63,7 +65,9 @@ TEST_CASE("move assign non empty", "[active_poller]")
     zmq::socket_t socket{context, zmq::socket_type::router};
 
     zmq::active_poller_t a;
-    a.add(socket, zmq::event_flags::pollin, [](zmq::event_flags) {});
+    a.add(socket, zmq::event_flags::pollin, [](zmq::event_flags)
+    {
+    });
     CHECK_FALSE(a.empty());
     CHECK(1u == a.size());
     zmq::active_poller_t b;
@@ -92,7 +96,9 @@ TEST_CASE("add handler invalid events type", "[active_poller]")
     zmq::active_poller_t active_poller;
     zmq::active_poller_t::handler_type handler;
     short invalid_events_type = 2 << 10;
-    CHECK_THROWS_AS(active_poller.add(socket, static_cast<zmq::event_flags>(invalid_events_type), handler), const zmq::error_t&);
+    CHECK_THROWS_AS(
+        active_poller.add(socket, static_cast<zmq::event_flags>(invalid_events_type),
+            handler), const zmq::error_t&);
     CHECK(active_poller.empty());
     CHECK(0u == active_poller.size());
 }
@@ -106,14 +112,16 @@ TEST_CASE("add handler twice throws", "[active_poller]")
     zmq::active_poller_t::handler_type handler;
     active_poller.add(socket, zmq::event_flags::pollin, handler);
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(active_poller.add(socket, zmq::event_flags::pollin, handler), const zmq::error_t&);
+    CHECK_THROWS_AS(active_poller.add(socket, zmq::event_flags::pollin, handler),
+                    const zmq::error_t&);
 }
 
 TEST_CASE("wait with no handlers throws", "[active_poller]")
 {
     zmq::active_poller_t active_poller;
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(active_poller.wait(std::chrono::milliseconds{10}), const zmq::error_t&);
+    CHECK_THROWS_AS(active_poller.wait(std::chrono::milliseconds{10}),
+                    const zmq::error_t&);
 }
 
 TEST_CASE("remove unregistered throws", "[active_poller]")
@@ -130,7 +138,8 @@ TEST_CASE("remove registered empty", "[active_poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
-    active_poller.add(socket, zmq::event_flags::pollin, zmq::active_poller_t::handler_type{});
+    active_poller.add(socket, zmq::event_flags::pollin,
+                      zmq::active_poller_t::handler_type{});
     CHECK_NOTHROW(active_poller.remove(socket));
 }
 
@@ -139,7 +148,9 @@ TEST_CASE("remove registered non empty", "[active_poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
-    active_poller.add(socket, zmq::event_flags::pollin, [](zmq::event_flags) {});
+    active_poller.add(socket, zmq::event_flags::pollin, [](zmq::event_flags)
+    {
+    });
     CHECK_NOTHROW(active_poller.remove(socket));
 }
 
@@ -147,7 +158,10 @@ namespace
 {
 struct server_client_setup : common_server_client_setup
 {
-    zmq::active_poller_t::handler_type handler = [&](zmq::event_flags e) { events = e; };
+    zmq::active_poller_t::handler_type handler = [&](zmq::event_flags e)
+    {
+        events = e;
+    };
 
     zmq::event_flags events = zmq::event_flags::none;
 };
@@ -161,7 +175,9 @@ TEST_CASE("poll basic", "[active_poller]")
 
     zmq::active_poller_t active_poller;
     bool message_received = false;
-    zmq::active_poller_t::handler_type handler = [&message_received](zmq::event_flags events) {
+    zmq::active_poller_t::handler_type handler = [&message_received
+        ](zmq::event_flags events)
+    {
         CHECK(zmq::event_flags::none != (events & zmq::event_flags::pollin));
         message_received = true;
     };
@@ -181,7 +197,8 @@ TEST_CASE("client server", "[active_poller]")
     // Setup active_poller
     zmq::active_poller_t active_poller;
     zmq::event_flags events;
-    zmq::active_poller_t::handler_type handler = [&](zmq::event_flags e) {
+    zmq::active_poller_t::handler_type handler = [&](zmq::event_flags e)
+    {
         if (zmq::event_flags::none != (e & zmq::event_flags::pollin)) {
             zmq::message_t zmq_msg;
             CHECK_NOTHROW(s.server.recv(zmq_msg)); // get message
@@ -204,7 +221,9 @@ TEST_CASE("client server", "[active_poller]")
 
     // Re-add server socket with pollout flag
     CHECK_NOTHROW(active_poller.remove(s.server));
-    CHECK_NOTHROW(active_poller.add(s.server, zmq::event_flags::pollin | zmq::event_flags::pollout, handler));
+    CHECK_NOTHROW(
+        active_poller.add(s.server, zmq::event_flags::pollin | zmq::event_flags::
+            pollout, handler));
     CHECK(1 == active_poller.wait(std::chrono::milliseconds{-1}));
     CHECK(events == zmq::event_flags::pollout);
 }
@@ -215,8 +234,10 @@ TEST_CASE("add invalid socket throws", "[active_poller]")
     zmq::active_poller_t active_poller;
     zmq::socket_t a{context, zmq::socket_type::router};
     zmq::socket_t b{std::move(a)};
-    CHECK_THROWS_AS(active_poller.add(a, zmq::event_flags::pollin, zmq::active_poller_t::handler_type{}),
-                 const zmq::error_t&);
+    CHECK_THROWS_AS(
+        active_poller.add(a, zmq::event_flags::pollin, zmq::active_poller_t::
+            handler_type{}),
+        const zmq::error_t&);
 }
 
 TEST_CASE("remove invalid socket throws", "[active_poller]")
@@ -225,7 +246,8 @@ TEST_CASE("remove invalid socket throws", "[active_poller]")
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
     CHECK_NOTHROW(
-      active_poller.add(socket, zmq::event_flags::pollin, zmq::active_poller_t::handler_type{}));
+        active_poller.add(socket, zmq::event_flags::pollin, zmq::active_poller_t::
+            handler_type{}));
     CHECK(1u == active_poller.size());
     std::vector<zmq::socket_t> sockets;
     sockets.emplace_back(std::move(socket));
@@ -248,7 +270,8 @@ TEST_CASE("modify empty throws", "[active_poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
-    CHECK_THROWS_AS(active_poller.modify(socket, zmq::event_flags::pollin), const zmq::error_t&);
+    CHECK_THROWS_AS(active_poller.modify(socket, zmq::event_flags::pollin),
+                    const zmq::error_t&);
 }
 
 TEST_CASE("modify invalid socket throws", "[active_poller]")
@@ -257,7 +280,8 @@ TEST_CASE("modify invalid socket throws", "[active_poller]")
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::socket_t b{std::move(a)};
     zmq::active_poller_t active_poller;
-    CHECK_THROWS_AS(active_poller.modify(a, zmq::event_flags::pollin), const zmq::error_t&);
+    CHECK_THROWS_AS(active_poller.modify(a, zmq::event_flags::pollin),
+                    const zmq::error_t&);
 }
 
 TEST_CASE("modify not added throws", "[active_poller]")
@@ -267,8 +291,10 @@ TEST_CASE("modify not added throws", "[active_poller]")
     zmq::socket_t b{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
     CHECK_NOTHROW(
-      active_poller.add(a, zmq::event_flags::pollin, zmq::active_poller_t::handler_type{}));
-    CHECK_THROWS_AS(active_poller.modify(b, zmq::event_flags::pollin), const zmq::error_t&);
+        active_poller.add(a, zmq::event_flags::pollin, zmq::active_poller_t::
+            handler_type{}));
+    CHECK_THROWS_AS(active_poller.modify(b, zmq::event_flags::pollin),
+                    const zmq::error_t&);
 }
 
 TEST_CASE("modify simple", "[active_poller]")
@@ -277,8 +303,11 @@ TEST_CASE("modify simple", "[active_poller]")
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
     CHECK_NOTHROW(
-      active_poller.add(a, zmq::event_flags::pollin, zmq::active_poller_t::handler_type{}));
-    CHECK_NOTHROW(active_poller.modify(a, zmq::event_flags::pollin | zmq::event_flags::pollout));
+        active_poller.add(a, zmq::event_flags::pollin, zmq::active_poller_t::
+            handler_type{}));
+    CHECK_NOTHROW(
+        active_poller.modify(a, zmq::event_flags::pollin | zmq::event_flags::pollout
+        ));
 }
 
 TEST_CASE("poll client server", "[active_poller]")
@@ -298,7 +327,9 @@ TEST_CASE("poll client server", "[active_poller]")
     CHECK(s.events == zmq::event_flags::pollin);
 
     // Modify server socket with pollout flag
-    CHECK_NOTHROW(active_poller.modify(s.server, zmq::event_flags::pollin | zmq::event_flags::pollout));
+    CHECK_NOTHROW(
+        active_poller.modify(s.server, zmq::event_flags::pollin | zmq::event_flags::
+            pollout));
     CHECK(1 == active_poller.wait(std::chrono::milliseconds{500}));
     CHECK(s.events == (zmq::event_flags::pollin | zmq::event_flags::pollout));
 }
@@ -313,7 +344,8 @@ TEST_CASE("wait one return", "[active_poller]")
     // Setup active_poller
     zmq::active_poller_t active_poller;
     CHECK_NOTHROW(
-      active_poller.add(s.server, zmq::event_flags::pollin, [&count](zmq::event_flags) { ++count; }));
+        active_poller.add(s.server, zmq::event_flags::pollin, [&count](zmq::
+            event_flags) { ++count; }));
 
     // client sends message
     CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
@@ -359,7 +391,9 @@ TEST_CASE("received on move constructed active_poller", "[active_poller]")
     int count = 0;
     // Setup active_poller a
     zmq::active_poller_t a;
-    CHECK_NOTHROW(a.add(s.server, zmq::event_flags::pollin, [&count](zmq::event_flags) { ++count; }));
+    CHECK_NOTHROW(
+        a.add(s.server, zmq::event_flags::pollin, [&count](zmq::event_flags) { ++
+            count; }));
     // client sends message
     CHECK_NOTHROW(s.client.send(zmq::message_t{"Hi"}, zmq::send_flags::none));
     // wait for message and verify it is received
@@ -389,11 +423,12 @@ TEST_CASE("remove from handler", "[active_poller]")
     int count = 0;
     for (size_t i = 0; i < ITER_NO; ++i) {
         CHECK_NOTHROW(
-          active_poller.add(setup_list[i].server, zmq::event_flags::pollin, [&, i](zmq::event_flags events) {
-              CHECK(events == zmq::event_flags::pollin);
-              active_poller.remove(setup_list[ITER_NO - i - 1].server);
-              CHECK((ITER_NO - i - 1) == active_poller.size());
-          }));
+            active_poller.add(setup_list[i].server, zmq::event_flags::pollin, [&, i](
+                    zmq::event_flags events) {
+                CHECK(events == zmq::event_flags::pollin);
+                active_poller.remove(setup_list[ITER_NO - i - 1].server);
+                CHECK((ITER_NO - i - 1) == active_poller.size());
+                }));
         ++count;
     }
     CHECK(ITER_NO == active_poller.size());

--- a/tests/buffer.cpp
+++ b/tests/buffer.cpp
@@ -35,10 +35,10 @@ TEST_CASE("buffer data ctor", "[buffer]")
     CHECK(mb.size() == from_mut.size());
     CHECK(mb.data() == from_mut.data());
     const auto cmb = mb;
-    static_assert(std::is_same<decltype(cmb.data()), void*>::value, "");
+    static_assert(std::is_same<decltype(cmb.data()), void *>::value, "");
 
-    constexpr const void* cp = nullptr;
-    constexpr void* p = nullptr;
+    constexpr const void *cp = nullptr;
+    constexpr void *p = nullptr;
     constexpr zmq::const_buffer cecb = zmq::buffer(p, 0);
     constexpr zmq::mutable_buffer cemb = zmq::buffer(p, 0);
     CHECK(cecb.data() == nullptr);
@@ -188,14 +188,14 @@ TEST_CASE("mutable_buffer creation vector", "[buffer]")
 TEST_CASE("const_buffer creation vector", "[buffer]")
 {
     std::vector<BT> d(10);
-    zmq::const_buffer b = zmq::buffer(static_cast<const std::vector<BT>&>(d));
+    zmq::const_buffer b = zmq::buffer(static_cast<const std::vector<BT> &>(d));
     CHECK(b.size() == d.size() * sizeof(BT));
     CHECK(b.data() == d.data());
-    zmq::const_buffer b2 = zmq::buffer(static_cast<const std::vector<BT>&>(d), 4);
+    zmq::const_buffer b2 = zmq::buffer(static_cast<const std::vector<BT> &>(d), 4);
     CHECK(b2.size() == 4);
     CHECK(b2.data() == d.data());
     d.clear();
-    b = zmq::buffer(static_cast<const std::vector<BT>&>(d));
+    b = zmq::buffer(static_cast<const std::vector<BT> &>(d));
     CHECK(b.size() == 0);
     CHECK(b.data() == nullptr);
 }

--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -4,9 +4,9 @@
 
 #if defined(ZMQ_CPP11)
 static_assert(!std::is_copy_constructible<zmq::message_t>::value,
-              "message_t should not be copy-constructible");
+    "message_t should not be copy-constructible");
 static_assert(!std::is_copy_assignable<zmq::message_t>::value,
-              "message_t should not be copy-assignable");
+    "message_t should not be copy-assignable");
 #endif
 #if (__cplusplus >= 201703L)
 static_assert(std::is_nothrow_swappable<zmq::message_t>::value,
@@ -36,7 +36,8 @@ TEST_CASE("message swap", "[message]")
 }
 #endif
 
-namespace {
+namespace
+{
 const char *const data = "Hi";
 }
 

--- a/tests/monitor.cpp
+++ b/tests/monitor.cpp
@@ -8,7 +8,7 @@
 
 class mock_monitor_t : public zmq::monitor_t
 {
-  public:
+public:
     void on_event_connect_delayed(const zmq_event_t &, const char *) ZMQ_OVERRIDE
     {
         ++connect_delayed;
@@ -38,13 +38,11 @@ TEST_CASE("monitor move construct", "[monitor]")
 {
     zmq::context_t ctx;
     zmq::socket_t sock(ctx, ZMQ_DEALER);
-    SECTION("move ctor empty")
-    {
+    SECTION("move ctor empty") {
         zmq::monitor_t monitor1;
         zmq::monitor_t monitor2 = std::move(monitor1);
     }
-    SECTION("move ctor init")
-    {
+    SECTION("move ctor init") {
         zmq::monitor_t monitor1;
         monitor1.init(sock, "inproc://monitor-client");
         zmq::monitor_t monitor2 = std::move(monitor1);
@@ -55,21 +53,18 @@ TEST_CASE("monitor move assign", "[monitor]")
 {
     zmq::context_t ctx;
     zmq::socket_t sock(ctx, ZMQ_DEALER);
-    SECTION("move assign empty")
-    {
-      zmq::monitor_t monitor1;
-      zmq::monitor_t monitor2;
-      monitor1 = std::move(monitor2);
+    SECTION("move assign empty") {
+        zmq::monitor_t monitor1;
+        zmq::monitor_t monitor2;
+        monitor1 = std::move(monitor2);
     }
-    SECTION("move assign init")
-    {
+    SECTION("move assign init") {
         zmq::monitor_t monitor1;
         monitor1.init(sock, "inproc://monitor-client");
         zmq::monitor_t monitor2;
         monitor2 = std::move(monitor1);
     }
-    SECTION("move assign init both")
-    {
+    SECTION("move assign init both") {
         zmq::monitor_t monitor1;
         monitor1.init(sock, "inproc://monitor-client");
         zmq::monitor_t monitor2;
@@ -101,10 +96,11 @@ TEST_CASE("monitor init abort", "[monitor]")
 {
     class mock_monitor : public mock_monitor_t
     {
-      public:
-        mock_monitor(std::function<void(void)> handle_connected)
-            : handle_connected{std::move(handle_connected)}
-        {}
+    public:
+        mock_monitor(std::function<void(void)> handle_connected) :
+            handle_connected{std::move(handle_connected)}
+        {
+        }
 
         void on_event_connected(const zmq_event_t &e, const char *m) ZMQ_OVERRIDE
         {
@@ -113,7 +109,6 @@ TEST_CASE("monitor init abort", "[monitor]")
         }
 
         std::function<void(void)> handle_connected;
-
     };
 
     common_server_client_setup s(false);
@@ -122,14 +117,16 @@ TEST_CASE("monitor init abort", "[monitor]")
     std::condition_variable cond_var;
     bool done{false};
 
-    mock_monitor monitor([&]() {
+    mock_monitor monitor([&]()
+    {
         std::lock_guard<std::mutex> lock(mutex);
         done = true;
         cond_var.notify_one();
     });
     monitor.init(s.client, "inproc://foo");
 
-    auto thread = std::thread([&monitor] {
+    auto thread = std::thread([&monitor]
+    {
         while (monitor.check_event(-1)) {
         }
     });

--- a/tests/multipart.cpp
+++ b/tests/multipart.cpp
@@ -74,12 +74,12 @@ TEST_CASE("multipart legacy test", "[multipart]")
     multipart.pushtyp(1.0f);
     multipart.pushmem("Frame0", 6);
     assert(multipart.size() == 10);
-    
-    const message_t& front_msg = multipart.front();
+
+    const message_t &front_msg = multipart.front();
     assert(multipart.size() == 10);
     assert(std::string(front_msg.data<char>(), front_msg.size()) == "Frame0");
-    
-    const message_t& back_msg = multipart.back();
+
+    const message_t &back_msg = multipart.back();
     assert(multipart.size() == 10);
     assert(std::string(back_msg.data<char>(), back_msg.size()) == "Frame9");
 

--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -9,15 +9,16 @@
 static_assert(std::is_nothrow_swappable_v<zmq::poller_t<>>);
 #endif
 static_assert(sizeof(zmq_poller_event_t) == sizeof(zmq::poller_event<>), "");
-static_assert(sizeof(zmq_poller_event_t) == sizeof(zmq::poller_event<zmq::no_user_data>), "");
+static_assert(sizeof(zmq_poller_event_t) == sizeof(zmq::poller_event<zmq::
+                  no_user_data>), "");
 static_assert(sizeof(zmq_poller_event_t) == sizeof(zmq::poller_event<int>), "");
 static_assert(alignof(zmq_poller_event_t) == alignof(zmq::poller_event<>), "");
 static_assert(alignof(zmq_poller_event_t) == alignof(zmq::poller_event<int>), "");
 
 static_assert(!std::is_copy_constructible<zmq::poller_t<>>::value,
-              "poller_t should not be copy-constructible");
+    "poller_t should not be copy-constructible");
 static_assert(!std::is_copy_assignable<zmq::poller_t<>>::value,
-              "poller_t should not be copy-assignable");
+    "poller_t should not be copy-assignable");
 
 TEST_CASE("event flags", "[poller]")
 {
@@ -106,7 +107,9 @@ TEST_CASE("poller add handler invalid events type", "[poller]")
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::poller_t<> poller;
     short invalid_events_type = 2 << 10;
-    CHECK_THROWS_AS(poller.add(socket, static_cast<zmq::event_flags>(invalid_events_type)), const zmq::error_t&);
+    CHECK_THROWS_AS(
+        poller.add(socket, static_cast<zmq::event_flags>(invalid_events_type)),
+        const zmq::error_t&);
 }
 #endif
 
@@ -117,7 +120,8 @@ TEST_CASE("poller add handler twice throws", "[poller]")
     zmq::poller_t<> poller;
     poller.add(socket, zmq::event_flags::pollin);
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(poller.add(socket, zmq::event_flags::pollin), const zmq::error_t&);
+    CHECK_THROWS_AS(poller.add(socket, zmq::event_flags::pollin),
+                    const zmq::error_t&);
 }
 
 TEST_CASE("poller wait with no handlers throws", "[poller]")
@@ -126,7 +130,7 @@ TEST_CASE("poller wait with no handlers throws", "[poller]")
     std::vector<zmq::poller_event<>> events;
     /// \todo the actual error code should be checked
     CHECK_THROWS_AS(poller.wait_all(events, std::chrono::milliseconds{10}),
-                 const zmq::error_t&);
+                    const zmq::error_t&);
 }
 
 TEST_CASE("poller remove unregistered throws", "[poller]")
@@ -198,7 +202,8 @@ TEST_CASE("poller modify empty throws", "[poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::push};
     zmq::poller_t<> poller;
-    CHECK_THROWS_AS(poller.modify(socket, zmq::event_flags::pollin), const zmq::error_t&);
+    CHECK_THROWS_AS(poller.modify(socket, zmq::event_flags::pollin),
+                    const zmq::error_t&);
 }
 
 TEST_CASE("poller modify invalid socket throws", "[poller]")
@@ -226,7 +231,8 @@ TEST_CASE("poller modify simple", "[poller]")
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::poller_t<> poller;
     CHECK_NOTHROW(poller.add(a, zmq::event_flags::pollin));
-    CHECK_NOTHROW(poller.modify(a, zmq::event_flags::pollin | zmq::event_flags::pollout));
+    CHECK_NOTHROW(
+        poller.modify(a, zmq::event_flags::pollin | zmq::event_flags::pollout));
 }
 
 TEST_CASE("poller poll client server", "[poller]")
@@ -247,9 +253,12 @@ TEST_CASE("poller poll client server", "[poller]")
     CHECK(zmq::event_flags::pollin == events[0].events);
 
     // Modify server socket with pollout flag
-    CHECK_NOTHROW(poller.modify(s.server, zmq::event_flags::pollin | zmq::event_flags::pollout));
+    CHECK_NOTHROW(
+        poller.modify(s.server, zmq::event_flags::pollin | zmq::event_flags::pollout
+        ));
     CHECK(1 == poller.wait_all(events, std::chrono::milliseconds{500}));
-    CHECK((zmq::event_flags::pollin | zmq::event_flags::pollout) == events[0].events);
+    CHECK((zmq::event_flags::pollin | zmq::event_flags::pollout) == events[0].events)
+    ;
 }
 
 TEST_CASE("poller wait one return", "[poller]")
@@ -278,7 +287,8 @@ TEST_CASE("poller wait on move constructed", "[poller]")
     zmq::poller_t<> b{std::move(a)};
     std::vector<zmq::poller_event<>> events(1);
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(a.wait_all(events, std::chrono::milliseconds{10}), const zmq::error_t&);
+    CHECK_THROWS_AS(a.wait_all(events, std::chrono::milliseconds{10}),
+                    const zmq::error_t&);
     CHECK(1 == b.wait_all(events, std::chrono::milliseconds{-1}));
 }
 
@@ -292,7 +302,8 @@ TEST_CASE("poller wait on move assigned", "[poller]")
     b = {std::move(a)};
     /// \todo the TEST_CASE error code should be checked
     std::vector<zmq::poller_event<>> events(1);
-    CHECK_THROWS_AS(a.wait_all(events, std::chrono::milliseconds{10}), const zmq::error_t&);
+    CHECK_THROWS_AS(a.wait_all(events, std::chrono::milliseconds{10}),
+                    const zmq::error_t&);
     CHECK(1 == b.wait_all(events, std::chrono::milliseconds{-1}));
 }
 

--- a/tests/recv_multipart.cpp
+++ b/tests/recv_multipart.cpp
@@ -10,8 +10,7 @@ TEST_CASE("recv_multipart test", "[recv_multipart]")
     output.bind("inproc://multipart.test");
     input.connect("inproc://multipart.test");
 
-    SECTION("send 1 message")
-    {
+    SECTION("send 1 message") {
         input.send(zmq::str_buffer("hello"));
 
         std::vector<zmq::message_t> msgs;
@@ -21,8 +20,7 @@ TEST_CASE("recv_multipart test", "[recv_multipart]")
         REQUIRE(msgs.size() == 1);
         CHECK(msgs[0].size() == 5);
     }
-    SECTION("send 2 messages")
-    {
+    SECTION("send 2 messages") {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
         input.send(zmq::str_buffer("world!"));
 
@@ -34,26 +32,27 @@ TEST_CASE("recv_multipart test", "[recv_multipart]")
         CHECK(msgs[0].size() == 5);
         CHECK(msgs[1].size() == 6);
     }
-    SECTION("send no messages, dontwait")
-    {
+    SECTION("send no messages, dontwait") {
         std::vector<zmq::message_t> msgs;
-        auto ret = zmq::recv_multipart(output, std::back_inserter(msgs), zmq::recv_flags::dontwait);
+        auto ret = zmq::recv_multipart(output, std::back_inserter(msgs),
+                                       zmq::recv_flags::dontwait);
         CHECK_FALSE(ret);
         REQUIRE(msgs.size() == 0);
     }
-    SECTION("send 1 partial message, dontwait")
-    {
+    SECTION("send 1 partial message, dontwait") {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
 
         std::vector<zmq::message_t> msgs;
-        auto ret = zmq::recv_multipart(output, std::back_inserter(msgs), zmq::recv_flags::dontwait);
+        auto ret = zmq::recv_multipart(output, std::back_inserter(msgs),
+                                       zmq::recv_flags::dontwait);
         CHECK_FALSE(ret);
         REQUIRE(msgs.size() == 0);
     }
-    SECTION("recv with invalid socket")
-    {
+    SECTION("recv with invalid socket") {
         std::vector<zmq::message_t> msgs;
-        CHECK_THROWS_AS(zmq::recv_multipart(zmq::socket_ref(), std::back_inserter(msgs)), const zmq::error_t &);
+        CHECK_THROWS_AS(
+            zmq::recv_multipart(zmq::socket_ref(), std::back_inserter(msgs)),
+            const zmq::error_t &);
     }
 }
 
@@ -65,8 +64,7 @@ TEST_CASE("recv_multipart_n test", "[recv_multipart]")
     output.bind("inproc://multipart.test");
     input.connect("inproc://multipart.test");
 
-    SECTION("send 1 message")
-    {
+    SECTION("send 1 message") {
         input.send(zmq::str_buffer("hello"));
 
         std::array<zmq::message_t, 1> msgs;
@@ -75,8 +73,7 @@ TEST_CASE("recv_multipart_n test", "[recv_multipart]")
         CHECK(*ret == 1);
         CHECK(msgs[0].size() == 5);
     }
-    SECTION("send 1 message 2")
-    {
+    SECTION("send 1 message 2") {
         input.send(zmq::str_buffer("hello"));
 
         std::array<zmq::message_t, 2> msgs;
@@ -86,28 +83,25 @@ TEST_CASE("recv_multipart_n test", "[recv_multipart]")
         CHECK(msgs[0].size() == 5);
         CHECK(msgs[1].size() == 0);
     }
-    SECTION("send 2 messages, recv 1")
-    {
+    SECTION("send 2 messages, recv 1") {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
         input.send(zmq::str_buffer("world!"));
 
         std::array<zmq::message_t, 1> msgs;
         CHECK_THROWS_AS(
-            zmq::recv_multipart_n(output, msgs.data(), msgs.size()), 
+            zmq::recv_multipart_n(output, msgs.data(), msgs.size()),
             const std::runtime_error&);
     }
-    SECTION("recv 0")
-    {
+    SECTION("recv 0") {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
         input.send(zmq::str_buffer("world!"));
 
         std::array<zmq::message_t, 1> msgs;
         CHECK_THROWS_AS(
-            zmq::recv_multipart_n(output, msgs.data(), 0), 
+            zmq::recv_multipart_n(output, msgs.data(), 0),
             const std::runtime_error&);
     }
-    SECTION("send 2 messages")
-    {
+    SECTION("send 2 messages") {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
         input.send(zmq::str_buffer("world!"));
 
@@ -118,26 +112,27 @@ TEST_CASE("recv_multipart_n test", "[recv_multipart]")
         CHECK(msgs[0].size() == 5);
         CHECK(msgs[1].size() == 6);
     }
-    SECTION("send no messages, dontwait")
-    {
+    SECTION("send no messages, dontwait") {
         std::array<zmq::message_t, 1> msgs;
-        auto ret = zmq::recv_multipart_n(output, msgs.data(), msgs.size(), zmq::recv_flags::dontwait);
+        auto ret = zmq::recv_multipart_n(output, msgs.data(), msgs.size(),
+                                         zmq::recv_flags::dontwait);
         CHECK_FALSE(ret);
         REQUIRE(msgs[0].size() == 0);
     }
-    SECTION("send 1 partial message, dontwait")
-    {
+    SECTION("send 1 partial message, dontwait") {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
-        
+
         std::array<zmq::message_t, 1> msgs;
-        auto ret = zmq::recv_multipart_n(output, msgs.data(), msgs.size(), zmq::recv_flags::dontwait);
+        auto ret = zmq::recv_multipart_n(output, msgs.data(), msgs.size(),
+                                         zmq::recv_flags::dontwait);
         CHECK_FALSE(ret);
         REQUIRE(msgs[0].size() == 0);
     }
-    SECTION("recv with invalid socket")
-    {
+    SECTION("recv with invalid socket") {
         std::array<zmq::message_t, 1> msgs;
-        CHECK_THROWS_AS(zmq::recv_multipart_n(zmq::socket_ref(), msgs.data(), msgs.size()), const zmq::error_t &);
+        CHECK_THROWS_AS(
+            zmq::recv_multipart_n(zmq::socket_ref(), msgs.data(), msgs.size()),
+            const zmq::error_t &);
     }
 }
 

--- a/tests/send_multipart.cpp
+++ b/tests/send_multipart.cpp
@@ -12,15 +12,13 @@ TEST_CASE("send_multipart test", "[send_multipart]")
     output.bind("inproc://multipart.test");
     input.connect("inproc://multipart.test");
 
-    SECTION("send 0 messages")
-    {
+    SECTION("send 0 messages") {
         std::vector<zmq::message_t> imsgs;
         auto iret = zmq::send_multipart(input, imsgs);
         REQUIRE(iret);
         CHECK(*iret == 0);
     }
-    SECTION("send 1 message")
-    {
+    SECTION("send 1 message") {
         std::array<zmq::message_t, 1> imsgs = {zmq::message_t(3)};
         auto iret = zmq::send_multipart(input, imsgs);
         REQUIRE(iret);
@@ -33,8 +31,7 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         REQUIRE(omsgs.size() == 1);
         CHECK(omsgs[0].size() == 3);
     }
-    SECTION("send 2 messages")
-    {
+    SECTION("send 2 messages") {
         std::array<zmq::message_t, 2> imsgs = {zmq::message_t(3), zmq::message_t(4)};
         auto iret = zmq::send_multipart(input, imsgs);
         REQUIRE(iret);
@@ -48,9 +45,9 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         CHECK(omsgs[0].size() == 3);
         CHECK(omsgs[1].size() == 4);
     }
-    SECTION("send 2 messages, const_buffer")
-    {
-        std::array<zmq::const_buffer, 2> imsgs = {zmq::str_buffer("foo"), zmq::str_buffer("bar!")};
+    SECTION("send 2 messages, const_buffer") {
+        std::array<zmq::const_buffer, 2> imsgs = {zmq::str_buffer("foo"),
+                                                  zmq::str_buffer("bar!")};
         auto iret = zmq::send_multipart(input, imsgs);
         REQUIRE(iret);
         CHECK(*iret == 2);
@@ -63,10 +60,10 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         CHECK(omsgs[0].size() == 3);
         CHECK(omsgs[1].size() == 4);
     }
-    SECTION("send 2 messages, mutable_buffer")
-    {
+    SECTION("send 2 messages, mutable_buffer") {
         char buf[4] = {};
-        std::array<zmq::mutable_buffer, 2> imsgs = {zmq::buffer(buf, 3), zmq::buffer(buf)};
+        std::array<zmq::mutable_buffer, 2> imsgs = {
+            zmq::buffer(buf, 3), zmq::buffer(buf)};
         auto iret = zmq::send_multipart(input, imsgs);
         REQUIRE(iret);
         CHECK(*iret == 2);
@@ -79,17 +76,15 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         CHECK(omsgs[0].size() == 3);
         CHECK(omsgs[1].size() == 4);
     }
-    SECTION("send 2 messages, dontwait")
-    {
+    SECTION("send 2 messages, dontwait") {
         zmq::socket_t push(context, ZMQ_PUSH);
         push.bind("inproc://multipart.test.push");
-        
+
         std::array<zmq::message_t, 2> imsgs = {zmq::message_t(3), zmq::message_t(4)};
         auto iret = zmq::send_multipart(push, imsgs, zmq::send_flags::dontwait);
         REQUIRE_FALSE(iret);
     }
-    SECTION("send, misc. containers")
-    {
+    SECTION("send, misc. containers") {
         std::vector<zmq::message_t> msgs_vec;
         msgs_vec.emplace_back(3);
         msgs_vec.emplace_back(4);
@@ -110,15 +105,17 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         REQUIRE(iret);
         CHECK(*iret == 2);
         // rvalue
-        iret = zmq::send_multipart(input, 
-            std::initializer_list<zmq::const_buffer>{zmq::str_buffer("foo"), zmq::str_buffer("bar!")});
+        iret = zmq::send_multipart(input,
+                                   std::initializer_list<zmq::const_buffer>{
+                                       zmq::str_buffer("foo"),
+                                       zmq::str_buffer("bar!")});
         REQUIRE(iret);
         CHECK(*iret == 2);
     }
-    SECTION("send with invalid socket")
-    {
+    SECTION("send with invalid socket") {
         std::vector<zmq::message_t> msgs(1);
-        CHECK_THROWS_AS(zmq::send_multipart(zmq::socket_ref(), msgs), const zmq::error_t &);
+        CHECK_THROWS_AS(zmq::send_multipart(zmq::socket_ref(), msgs),
+                        const zmq::error_t &);
     }
 }
 #endif

--- a/tests/socket.cpp
+++ b/tests/socket.cpp
@@ -50,19 +50,19 @@ TEST_CASE("socket swap", "[socket]")
 TEST_CASE("socket flags", "[socket]")
 {
     CHECK((zmq::recv_flags::dontwait | zmq::recv_flags::none)
-          == static_cast<zmq::recv_flags>(ZMQ_DONTWAIT | 0));
+        == static_cast<zmq::recv_flags>(ZMQ_DONTWAIT | 0));
     CHECK((zmq::recv_flags::dontwait & zmq::recv_flags::none)
-          == static_cast<zmq::recv_flags>(ZMQ_DONTWAIT & 0));
+        == static_cast<zmq::recv_flags>(ZMQ_DONTWAIT & 0));
     CHECK((zmq::recv_flags::dontwait ^ zmq::recv_flags::none)
-          == static_cast<zmq::recv_flags>(ZMQ_DONTWAIT ^ 0));
+        == static_cast<zmq::recv_flags>(ZMQ_DONTWAIT ^ 0));
     CHECK(~zmq::recv_flags::dontwait == static_cast<zmq::recv_flags>(~ZMQ_DONTWAIT));
 
     CHECK((zmq::send_flags::dontwait | zmq::send_flags::sndmore)
-          == static_cast<zmq::send_flags>(ZMQ_DONTWAIT | ZMQ_SNDMORE));
+        == static_cast<zmq::send_flags>(ZMQ_DONTWAIT | ZMQ_SNDMORE));
     CHECK((zmq::send_flags::dontwait & zmq::send_flags::sndmore)
-          == static_cast<zmq::send_flags>(ZMQ_DONTWAIT & ZMQ_SNDMORE));
+        == static_cast<zmq::send_flags>(ZMQ_DONTWAIT & ZMQ_SNDMORE));
     CHECK((zmq::send_flags::dontwait ^ zmq::send_flags::sndmore)
-          == static_cast<zmq::send_flags>(ZMQ_DONTWAIT ^ ZMQ_SNDMORE));
+        == static_cast<zmq::send_flags>(ZMQ_DONTWAIT ^ ZMQ_SNDMORE));
     CHECK(~zmq::send_flags::dontwait == static_cast<zmq::send_flags>(~ZMQ_DONTWAIT));
 }
 
@@ -82,20 +82,20 @@ TEST_CASE("socket sends and receives const buffer", "[socket]")
     zmq::socket_t receiver(context, ZMQ_PAIR);
     receiver.bind("inproc://test");
     sender.connect("inproc://test");
-    const char* str = "Hi";
+    const char *str = "Hi";
 
-    #ifdef ZMQ_CPP11
+#ifdef ZMQ_CPP11
     CHECK(2 == *sender.send(zmq::buffer(str, 2)));
     char buf[2];
     const auto res = receiver.recv(zmq::buffer(buf));
     CHECK(res);
     CHECK(!res->truncated());
     CHECK(2 == res->size);
-    #else
+#else
     CHECK(2 == sender.send(str, 2));
     char buf[2];
     CHECK(2 == receiver.recv(buf, 2));
-    #endif
+#endif
     CHECK(0 == memcmp(buf, str, 2));
 }
 
@@ -126,7 +126,7 @@ TEST_CASE("socket send dontwait", "[socket]")
     auto res = s.send(zmq::buffer(buf), zmq::send_flags::dontwait);
     CHECK(!res);
     res = s.send(zmq::buffer(buf),
-                  zmq::send_flags::dontwait | zmq::send_flags::sndmore);
+                 zmq::send_flags::dontwait | zmq::send_flags::sndmore);
     CHECK(!res);
 
     zmq::message_t msg;
@@ -253,16 +253,15 @@ TEST_CASE("socket proxy", "[socket]")
     front.bind("inproc://test1");
     back.bind("inproc://test2");
     capture.bind("inproc://test3");
-    auto f = std::async(std::launch::async, [&]() {
+    auto f = std::async(std::launch::async, [&]()
+    {
         auto s1 = std::move(front);
         auto s2 = std::move(back);
         auto s3 = std::move(capture);
-        try
-        {
+        try {
             zmq::proxy(s1, s2, zmq::socket_ref(s3));
         }
-        catch (const zmq::error_t& e)
-        {
+        catch (const zmq::error_t &e) {
             return e.num() == ETERM;
         }
         return false;
@@ -280,16 +279,15 @@ TEST_CASE("socket proxy steerable", "[socket]")
     front.bind("inproc://test1");
     back.bind("inproc://test2");
     control.connect("inproc://test3");
-    auto f = std::async(std::launch::async, [&]() {
+    auto f = std::async(std::launch::async, [&]()
+    {
         auto s1 = std::move(front);
         auto s2 = std::move(back);
         auto s3 = std::move(control);
-        try
-        {
+        try {
             zmq::proxy_steerable(s1, s2, zmq::socket_ref(), s3);
         }
-        catch (const zmq::error_t& e)
-        {
+        catch (const zmq::error_t &e) {
             return e.num() == ETERM;
         }
         return false;

--- a/tests/socket_ref.cpp
+++ b/tests/socket_ref.cpp
@@ -8,7 +8,7 @@ static_assert(std::is_nothrow_swappable_v<zmq::socket_ref>);
 static_assert(sizeof(zmq::socket_ref) == sizeof(void *), "size mismatch");
 static_assert(alignof(zmq::socket_ref) == alignof(void *), "alignment mismatch");
 static_assert(ZMQ_IS_TRIVIALLY_COPYABLE(zmq::socket_ref),
-              "needs to be trivially copyable");
+    "needs to be trivially copyable");
 
 TEST_CASE("socket_ref default init", "[socket_ref]")
 {
@@ -111,7 +111,7 @@ TEST_CASE("socket_ref type punning", "[socket_ref]")
     CHECK(socket.handle() != nullptr);
     svp.p = socket.handle();
     // static_cast to silence incorrect warning
-    std::memcpy(static_cast<void*>(&ssr), &svp, sizeof(ssr));
+    std::memcpy(static_cast<void *>(&ssr), &svp, sizeof(ssr));
     CHECK(ssr.sr == socket);
 }
 

--- a/tests/utilities.cpp
+++ b/tests/utilities.cpp
@@ -8,31 +8,38 @@ namespace test_ns
 struct T_nr
 {
 };
+
 struct T_mr
 {
     void *begin() const noexcept { return nullptr; }
     void *end() const noexcept { return nullptr; }
 };
+
 struct T_fr
 {
 };
+
 inline void *begin(const T_fr &) noexcept
 {
     return nullptr;
 }
+
 inline void *end(const T_fr &) noexcept
 {
     return nullptr;
 }
+
 struct T_mfr
 {
     void *begin() const noexcept { return nullptr; }
     void *end() const noexcept { return nullptr; }
 };
+
 inline void *begin(const T_mfr &) noexcept
 {
     return nullptr;
 }
+
 inline void *end(const T_mfr &) noexcept
 {
     return nullptr;
@@ -42,31 +49,38 @@ inline void *end(const T_mfr &) noexcept
 struct T_assoc_ns_nr : std::exception
 {
 };
+
 struct T_assoc_ns_mr : std::exception
 {
     void *begin() const noexcept { return nullptr; }
     void *end() const noexcept { return nullptr; }
 };
+
 struct T_assoc_ns_fr : std::exception
 {
 };
+
 inline void *begin(const T_assoc_ns_fr &) noexcept
 {
     return nullptr;
 }
+
 inline void *end(const T_assoc_ns_fr &) noexcept
 {
     return nullptr;
 }
+
 struct T_assoc_ns_mfr : std::exception
 {
     void *begin() const noexcept { return nullptr; }
     void *end() const noexcept { return nullptr; }
 };
+
 inline void *begin(const T_assoc_ns_mfr &) noexcept
 {
     return nullptr;
 }
+
 inline void *end(const T_assoc_ns_mfr &) noexcept
 {
     return nullptr;

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -27,16 +27,20 @@
 #define __ZMQ_HPP_INCLUDED__
 
 // macros defined if has a specific standard or greater
-#if (defined(__cplusplus) && __cplusplus >= 201103L) || (defined(_MSC_VER) && _MSC_VER >= 1900)
-    #define ZMQ_CPP11
+#if (defined(__cplusplus) && __cplusplus >= 201103L)                                \
+  || (defined(_MSC_VER) && _MSC_VER >= 1900)
+#define ZMQ_CPP11
 #endif
-#if (defined(__cplusplus) && __cplusplus >= 201402L) || \
-    (defined(_HAS_CXX14) && _HAS_CXX14 == 1) || \
-    (defined(_HAS_CXX17) && _HAS_CXX17 == 1) // _HAS_CXX14 might not be defined when using C++17 on MSVC
-    #define ZMQ_CPP14
+#if (defined(__cplusplus) && __cplusplus >= 201402L)                                \
+  || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)                                       \
+  || (defined(_HAS_CXX17)                                                           \
+      && _HAS_CXX17                                                                 \
+           == 1) // _HAS_CXX14 might not be defined when using C++17 on MSVC
+#define ZMQ_CPP14
 #endif
-#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1)
-    #define ZMQ_CPP17
+#if (defined(__cplusplus) && __cplusplus >= 201703L)                                \
+  || (defined(_HAS_CXX17) && _HAS_CXX17 == 1)
+#define ZMQ_CPP17
 #endif
 
 #if defined(ZMQ_CPP14)
@@ -134,8 +138,8 @@
 #define ZMQ_DELETED_FUNCTION
 #endif
 
-#if defined(ZMQ_CPP11) && !defined(__llvm__) && !defined(__INTEL_COMPILER) \
-    && defined(__GNUC__) && __GNUC__ < 5
+#if defined(ZMQ_CPP11) && !defined(__llvm__) && !defined(__INTEL_COMPILER)          \
+  && defined(__GNUC__) && __GNUC__ < 5
 #define ZMQ_CPP11_PARTIAL
 #elif defined(__GLIBCXX__) && __GLIBCXX__ < 20160805
 //the date here is the last date of gcc 4.9.4, which
@@ -182,7 +186,6 @@ typedef struct
 
 namespace zmq
 {
-
 #ifdef ZMQ_CPP11
 namespace detail
 {
@@ -190,13 +193,11 @@ namespace ranges
 {
 using std::begin;
 using std::end;
-template<class T>
-auto begin(T&& r) -> decltype(begin(std::forward<T>(r)))
+template<class T> auto begin(T &&r) -> decltype(begin(std::forward<T>(r)))
 {
     return begin(std::forward<T>(r));
 }
-template<class T>
-auto end(T&& r) -> decltype(end(std::forward<T>(r)))
+template<class T> auto end(T &&r) -> decltype(end(std::forward<T>(r)))
 {
     return end(std::forward<T>(r));
 }
@@ -211,8 +212,7 @@ template<class Range>
 using range_iter_t = decltype(
   ranges::begin(std::declval<typename std::remove_reference<Range>::type &>()));
 
-template<class Range>
-using range_value_t = iter_value_t<range_iter_t<Range>>;
+template<class Range> using range_value_t = iter_value_t<range_iter_t<Range>>;
 
 template<class T, class = void> struct is_range : std::false_type
 {
@@ -238,7 +238,10 @@ class error_t : public std::exception
 {
   public:
     error_t() : errnum(zmq_errno()) {}
-    virtual const char *what() const ZMQ_NOTHROW ZMQ_OVERRIDE { return zmq_strerror(errnum); }
+    virtual const char *what() const ZMQ_NOTHROW ZMQ_OVERRIDE
+    {
+        return zmq_strerror(errnum);
+    }
     int num() const { return errnum; }
 
   private:
@@ -264,14 +267,16 @@ ZMQ_DEPRECATED("from 4.3.1, use poll taking non-const items")
 inline int
 poll(zmq_pollitem_t const *items, size_t nitems, std::chrono::milliseconds timeout)
 {
-    return poll(const_cast<zmq_pollitem_t *>(items), nitems, static_cast<long>(timeout.count()));
+    return poll(const_cast<zmq_pollitem_t *>(items), nitems,
+                static_cast<long>(timeout.count()));
 }
 
 ZMQ_DEPRECATED("from 4.3.1, use poll taking non-const items")
 inline int poll(std::vector<zmq_pollitem_t> const &items,
                 std::chrono::milliseconds timeout)
 {
-    return poll(const_cast<zmq_pollitem_t *>(items.data()), items.size(), static_cast<long>(timeout.count()));
+    return poll(const_cast<zmq_pollitem_t *>(items.data()), items.size(),
+                static_cast<long>(timeout.count()));
 }
 
 ZMQ_DEPRECATED("from 4.3.1, use poll taking non-const items")
@@ -477,10 +482,7 @@ class message_t
         return zmq_msg_size(const_cast<zmq_msg_t *>(&msg));
     }
 
-    ZMQ_NODISCARD bool empty() const ZMQ_NOTHROW
-    {
-        return size() == 0u;
-    }
+    ZMQ_NODISCARD bool empty() const ZMQ_NOTHROW { return size() == 0u; }
 
     template<typename T> T *data() ZMQ_NOTHROW { return static_cast<T *>(data()); }
 
@@ -490,10 +492,7 @@ class message_t
     }
 
     ZMQ_DEPRECATED("from 4.3.0, use operator== instead")
-    bool equal(const message_t *other) const ZMQ_NOTHROW
-    {
-        return *this == *other;
-    }
+    bool equal(const message_t *other) const ZMQ_NOTHROW { return *this == *other; }
 
     bool operator==(const message_t &other) const ZMQ_NOTHROW
     {
@@ -529,7 +528,7 @@ class message_t
 #if defined(ZMQ_BUILD_DRAFT_API) && ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 0)
     uint32_t routing_id() const
     {
-        return zmq_msg_routing_id(const_cast<zmq_msg_t*>(&msg));
+        return zmq_msg_routing_id(const_cast<zmq_msg_t *>(&msg));
     }
 
     void set_routing_id(uint32_t routing_id)
@@ -539,12 +538,12 @@ class message_t
             throw error_t();
     }
 
-    const char* group() const
+    const char *group() const
     {
-        return zmq_msg_group(const_cast<zmq_msg_t*>(&msg));
+        return zmq_msg_group(const_cast<zmq_msg_t *>(&msg));
     }
 
-    void set_group(const char* group)
+    void set_group(const char *group)
     {
         int rc = zmq_msg_set_group(&msg, group);
         if (rc != 0)
@@ -555,13 +554,13 @@ class message_t
     // interpret message content as a string
     std::string to_string() const
     {
-        return std::string(static_cast<const char*>(data()), size());
+        return std::string(static_cast<const char *>(data()), size());
     }
 #ifdef ZMQ_CPP17
     // interpret message content as a string
     std::string_view to_string_view() const noexcept
     {
-        return std::string_view(static_cast<const char*>(data()), size());
+        return std::string_view(static_cast<const char *>(data()), size());
     }
 #endif
 
@@ -642,8 +641,7 @@ class context_t
     }
 
 
-    explicit context_t(int io_threads_,
-                              int max_sockets_ = ZMQ_MAX_SOCKETS_DFLT)
+    explicit context_t(int io_threads_, int max_sockets_ = ZMQ_MAX_SOCKETS_DFLT)
     {
         ptr = zmq_ctx_new();
         if (ptr == ZMQ_NULLPTR)
@@ -712,10 +710,7 @@ class context_t
 
     operator bool() const ZMQ_NOTHROW { return ptr != ZMQ_NULLPTR; }
 
-    void swap(context_t &other) ZMQ_NOTHROW
-    {
-        std::swap(ptr, other.ptr);
-    }
+    void swap(context_t &other) ZMQ_NOTHROW { std::swap(ptr, other.ptr); }
 
   private:
     void *ptr;
@@ -724,7 +719,8 @@ class context_t
     void operator=(const context_t &) ZMQ_DELETED_FUNCTION;
 };
 
-inline void swap(context_t &a, context_t &b) ZMQ_NOTHROW {
+inline void swap(context_t &a, context_t &b) ZMQ_NOTHROW
+{
     a.swap(b);
 }
 
@@ -732,8 +728,8 @@ inline void swap(context_t &a, context_t &b) ZMQ_NOTHROW {
 
 struct recv_buffer_size
 {
-    size_t size;    // number of bytes written to buffer
-    size_t untruncated_size;  // untruncated message size in bytes
+    size_t size;             // number of bytes written to buffer
+    size_t untruncated_size; // untruncated message size in bytes
 
     ZMQ_NODISCARD bool truncated() const noexcept
     {
@@ -814,30 +810,25 @@ using recv_buffer_result_t = detail::trivial_optional<recv_buffer_size>;
 
 namespace detail
 {
-
-template<class T>
-constexpr T enum_bit_or(T a, T b) noexcept
+template<class T> constexpr T enum_bit_or(T a, T b) noexcept
 {
     static_assert(std::is_enum<T>::value, "must be enum");
     using U = typename std::underlying_type<T>::type;
     return static_cast<T>(static_cast<U>(a) | static_cast<U>(b));
 }
-template<class T>
-constexpr T enum_bit_and(T a, T b) noexcept
+template<class T> constexpr T enum_bit_and(T a, T b) noexcept
 {
     static_assert(std::is_enum<T>::value, "must be enum");
     using U = typename std::underlying_type<T>::type;
     return static_cast<T>(static_cast<U>(a) & static_cast<U>(b));
 }
-template<class T>
-constexpr T enum_bit_xor(T a, T b) noexcept
+template<class T> constexpr T enum_bit_xor(T a, T b) noexcept
 {
     static_assert(std::is_enum<T>::value, "must be enum");
     using U = typename std::underlying_type<T>::type;
     return static_cast<T>(static_cast<U>(a) ^ static_cast<U>(b));
 }
-template<class T>
-constexpr T enum_bit_not(T a) noexcept
+template<class T> constexpr T enum_bit_not(T a) noexcept
 {
     static_assert(std::is_enum<T>::value, "must be enum");
     using U = typename std::underlying_type<T>::type;
@@ -947,8 +938,7 @@ class const_buffer
 #endif
     }
     constexpr const_buffer(const mutable_buffer &mb) noexcept :
-        _data(mb.data()),
-        _size(mb.size())
+        _data(mb.data()), _size(mb.size())
     {
     }
 
@@ -980,40 +970,37 @@ inline const_buffer operator+(size_t n, const const_buffer &cb) noexcept
 
 // buffer creation
 
-constexpr mutable_buffer buffer(void* p, size_t n) noexcept
+constexpr mutable_buffer buffer(void *p, size_t n) noexcept
 {
     return mutable_buffer(p, n);
 }
-constexpr const_buffer buffer(const void* p, size_t n) noexcept
+constexpr const_buffer buffer(const void *p, size_t n) noexcept
 {
     return const_buffer(p, n);
 }
-constexpr mutable_buffer buffer(const mutable_buffer& mb) noexcept
+constexpr mutable_buffer buffer(const mutable_buffer &mb) noexcept
 {
     return mb;
 }
-inline mutable_buffer buffer(const mutable_buffer& mb, size_t n) noexcept
+inline mutable_buffer buffer(const mutable_buffer &mb, size_t n) noexcept
 {
     return mutable_buffer(mb.data(), (std::min)(mb.size(), n));
 }
-constexpr const_buffer buffer(const const_buffer& cb) noexcept
+constexpr const_buffer buffer(const const_buffer &cb) noexcept
 {
     return cb;
 }
-inline const_buffer buffer(const const_buffer& cb, size_t n) noexcept
+inline const_buffer buffer(const const_buffer &cb, size_t n) noexcept
 {
     return const_buffer(cb.data(), (std::min)(cb.size(), n));
 }
 
 namespace detail
 {
-
-template<class T>
-struct is_buffer
+template<class T> struct is_buffer
 {
-    static constexpr bool value = 
-        std::is_same<T, const_buffer>::value ||
-        std::is_same<T, mutable_buffer>::value;
+    static constexpr bool value =
+      std::is_same<T, const_buffer>::value || std::is_same<T, mutable_buffer>::value;
 };
 
 template<class T> struct is_pod_like
@@ -1181,38 +1168,36 @@ constexpr const_buffer str_buffer(const Char (&data)[N]) noexcept
 #ifdef ZMQ_CPP14
     assert(data[N - 1] == Char{0});
 #endif
-    return const_buffer(static_cast<const Char*>(data),
-                        (N - 1) * sizeof(Char));
+    return const_buffer(static_cast<const Char *>(data), (N - 1) * sizeof(Char));
 }
 
 namespace literals
 {
-    constexpr const_buffer operator"" _zbuf(const char* str, size_t len) noexcept
-    {
-        return const_buffer(str, len * sizeof(char));
-    }
-    constexpr const_buffer operator"" _zbuf(const wchar_t* str, size_t len) noexcept
-    {
-        return const_buffer(str, len * sizeof(wchar_t));
-    }
-    constexpr const_buffer operator"" _zbuf(const char16_t* str, size_t len) noexcept
-    {
-        return const_buffer(str, len * sizeof(char16_t));
-    }
-    constexpr const_buffer operator"" _zbuf(const char32_t* str, size_t len) noexcept
-    {
-        return const_buffer(str, len * sizeof(char32_t));
-    }
+constexpr const_buffer operator"" _zbuf(const char *str, size_t len) noexcept
+{
+    return const_buffer(str, len * sizeof(char));
+}
+constexpr const_buffer operator"" _zbuf(const wchar_t *str, size_t len) noexcept
+{
+    return const_buffer(str, len * sizeof(wchar_t));
+}
+constexpr const_buffer operator"" _zbuf(const char16_t *str, size_t len) noexcept
+{
+    return const_buffer(str, len * sizeof(char16_t));
+}
+constexpr const_buffer operator"" _zbuf(const char32_t *str, size_t len) noexcept
+{
+    return const_buffer(str, len * sizeof(char32_t));
+}
 }
 
 #endif // ZMQ_CPP11
 
 namespace detail
 {
-
 class socket_base
 {
-public:
+  public:
     socket_base() ZMQ_NOTHROW : _handle(ZMQ_NULLPTR) {}
     ZMQ_EXPLICIT socket_base(void *handle) ZMQ_NOTHROW : _handle(handle) {}
 
@@ -1310,7 +1295,8 @@ public:
 
     template<typename T>
 #ifdef ZMQ_CPP11
-    ZMQ_DEPRECATED("from 4.4.1, use send taking message_t or buffer (for contiguous ranges), and send_flags")
+    ZMQ_DEPRECATED("from 4.4.1, use send taking message_t or buffer (for contiguous "
+                   "ranges), and send_flags")
 #endif
     bool send(T first, T last, int flags_ = 0)
     {
@@ -1330,11 +1316,11 @@ public:
     bool send(message_t &&msg_,
               int flags_ = 0) // default until removed
     {
-        #ifdef ZMQ_CPP11
+#ifdef ZMQ_CPP11
         return send(msg_, static_cast<send_flags>(flags_)).has_value();
-        #else
+#else
         return send(msg_, flags_);
-        #endif
+#endif
     }
 #endif
 
@@ -1380,7 +1366,8 @@ public:
     }
 
 #ifdef ZMQ_CPP11
-    ZMQ_DEPRECATED("from 4.3.1, use recv taking a reference to message_t and recv_flags")
+    ZMQ_DEPRECATED(
+      "from 4.3.1, use recv taking a reference to message_t and recv_flags")
 #endif
     bool recv(message_t *msg_, int flags_ = 0)
     {
@@ -1395,13 +1382,14 @@ public:
 #ifdef ZMQ_CPP11
     ZMQ_NODISCARD
     recv_buffer_result_t recv(mutable_buffer buf,
-                                    recv_flags flags = recv_flags::none)
+                              recv_flags flags = recv_flags::none)
     {
         const int nbytes =
           zmq_recv(_handle, buf.data(), buf.size(), static_cast<int>(flags));
         if (nbytes >= 0) {
-            return recv_buffer_size{(std::min)(static_cast<size_t>(nbytes), buf.size()),
-                                 static_cast<size_t>(nbytes)};
+            return recv_buffer_size{
+              (std::min)(static_cast<size_t>(nbytes), buf.size()),
+              static_cast<size_t>(nbytes)};
         }
         if (zmq_errno() == EAGAIN)
             return {};
@@ -1411,7 +1399,8 @@ public:
     ZMQ_NODISCARD
     recv_result_t recv(message_t &msg, recv_flags flags = recv_flags::none)
     {
-        const int nbytes = zmq_msg_recv(msg.handle(), _handle, static_cast<int>(flags));
+        const int nbytes =
+          zmq_msg_recv(msg.handle(), _handle, static_cast<int>(flags));
         if (nbytes >= 0) {
             assert(msg.size() == static_cast<size_t>(nbytes));
             return static_cast<size_t>(nbytes);
@@ -1423,14 +1412,14 @@ public:
 #endif
 
 #if defined(ZMQ_BUILD_DRAFT_API) && ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 0)
-    void join(const char* group)
+    void join(const char *group)
     {
         int rc = zmq_join(_handle, group);
         if (rc != 0)
             throw error_t();
     }
 
-    void leave(const char* group)
+    void leave(const char *group)
     {
         int rc = zmq_leave(_handle, group);
         if (rc != 0)
@@ -1446,7 +1435,7 @@ public:
     // operator void* is removed from socket_t
     ZMQ_EXPLICIT operator bool() ZMQ_NOTHROW { return _handle != ZMQ_NULLPTR; }
 
-protected:
+  protected:
     void *_handle;
 };
 } // namespace detail
@@ -1479,11 +1468,14 @@ enum class socket_type : int
 
 struct from_handle_t
 {
-    struct _private {}; // disabling use other than with from_handle
+    struct _private
+    {
+    }; // disabling use other than with from_handle
     ZMQ_CONSTEXPR_FN ZMQ_EXPLICIT from_handle_t(_private /*p*/) ZMQ_NOTHROW {}
 };
 
-ZMQ_CONSTEXPR_VAR from_handle_t from_handle = from_handle_t(from_handle_t::_private());
+ZMQ_CONSTEXPR_VAR from_handle_t from_handle =
+  from_handle_t(from_handle_t::_private());
 
 // A non-owning nullable reference to a socket.
 // The reference is invalidated on socket close or destruction.
@@ -1495,7 +1487,9 @@ class socket_ref : public detail::socket_base
     socket_ref(std::nullptr_t) ZMQ_NOTHROW : detail::socket_base() {}
 #endif
     socket_ref(from_handle_t /*fh*/, void *handle) ZMQ_NOTHROW
-        : detail::socket_base(handle) {}
+        : detail::socket_base(handle)
+    {
+    }
 };
 
 #ifdef ZMQ_CPP11
@@ -1519,7 +1513,7 @@ inline bool operator!=(std::nullptr_t /*p*/, socket_ref sr) ZMQ_NOTHROW
 
 inline bool operator==(socket_ref a, socket_ref b) ZMQ_NOTHROW
 {
-    return std::equal_to<void*>()(a.handle(), b.handle());
+    return std::equal_to<void *>()(a.handle(), b.handle());
 }
 inline bool operator!=(socket_ref a, socket_ref b) ZMQ_NOTHROW
 {
@@ -1527,7 +1521,7 @@ inline bool operator!=(socket_ref a, socket_ref b) ZMQ_NOTHROW
 }
 inline bool operator<(socket_ref a, socket_ref b) ZMQ_NOTHROW
 {
-    return std::less<void*>()(a.handle(), b.handle());
+    return std::less<void *>()(a.handle(), b.handle());
 }
 inline bool operator>(socket_ref a, socket_ref b) ZMQ_NOTHROW
 {
@@ -1547,12 +1541,11 @@ inline bool operator>=(socket_ref a, socket_ref b) ZMQ_NOTHROW
 #ifdef ZMQ_CPP11
 namespace std
 {
-template<>
-struct hash<zmq::socket_ref>
+template<> struct hash<zmq::socket_ref>
 {
     size_t operator()(zmq::socket_ref sr) const ZMQ_NOTHROW
     {
-        return hash<void*>()(sr.handle());
+        return hash<void *>()(sr.handle());
     }
 };
 } // namespace std
@@ -1560,35 +1553,31 @@ struct hash<zmq::socket_ref>
 
 namespace zmq
 {
-
 class socket_t : public detail::socket_base
 {
     friend class monitor_t;
 
   public:
-    socket_t() ZMQ_NOTHROW
-      : detail::socket_base(ZMQ_NULLPTR)
-      , ctxptr(ZMQ_NULLPTR)
-    {
-    }
+    socket_t() ZMQ_NOTHROW : detail::socket_base(ZMQ_NULLPTR), ctxptr(ZMQ_NULLPTR) {}
 
-    socket_t(context_t &context_, int type_)
-        : detail::socket_base(zmq_socket(static_cast<void*>(context_), type_))
-        , ctxptr(static_cast<void*>(context_))
+    socket_t(context_t &context_, int type_) :
+        detail::socket_base(zmq_socket(static_cast<void *>(context_), type_)),
+        ctxptr(static_cast<void *>(context_))
     {
         if (_handle == ZMQ_NULLPTR)
             throw error_t();
     }
 
 #ifdef ZMQ_CPP11
-    socket_t(context_t &context_, socket_type type_)
-        : socket_t(context_, static_cast<int>(type_))
+    socket_t(context_t &context_, socket_type type_) :
+        socket_t(context_, static_cast<int>(type_))
     {
     }
 #endif
 
 #ifdef ZMQ_HAS_RVALUE_REFS
-    socket_t(socket_t &&rhs) ZMQ_NOTHROW : detail::socket_base(rhs._handle), ctxptr(rhs.ctxptr)
+    socket_t(socket_t &&rhs) ZMQ_NOTHROW : detail::socket_base(rhs._handle),
+                                           ctxptr(rhs.ctxptr)
     {
         rhs._handle = ZMQ_NULLPTR;
         rhs.ctxptr = ZMQ_NULLPTR;
@@ -1623,10 +1612,7 @@ class socket_t : public detail::socket_base
         std::swap(ctxptr, other.ctxptr);
     }
 
-    operator socket_ref() ZMQ_NOTHROW
-    {
-        return socket_ref(from_handle, _handle);
-    }
+    operator socket_ref() ZMQ_NOTHROW { return socket_ref(from_handle, _handle); }
 
   private:
     void *ctxptr;
@@ -1635,16 +1621,16 @@ class socket_t : public detail::socket_base
     void operator=(const socket_t &) ZMQ_DELETED_FUNCTION;
 
     // used by monitor_t
-    socket_t(void *context_, int type_)
-        : detail::socket_base(zmq_socket(context_, type_))
-        , ctxptr(context_)
+    socket_t(void *context_, int type_) :
+        detail::socket_base(zmq_socket(context_, type_)), ctxptr(context_)
     {
         if (_handle == ZMQ_NULLPTR)
             throw error_t();
     }
 };
 
-inline void swap(socket_t &a, socket_t &b) ZMQ_NOTHROW {
+inline void swap(socket_t &a, socket_t &b) ZMQ_NOTHROW
+{
     a.swap(b);
 }
 
@@ -1691,10 +1677,7 @@ class monitor_t
   public:
     monitor_t() : _socket(), _monitor_socket() {}
 
-    virtual ~monitor_t()
-    {
-        close();
-    }
+    virtual ~monitor_t() { close(); }
 
 #ifdef ZMQ_HAS_RVALUE_REFS
     monitor_t(monitor_t &&rhs) ZMQ_NOTHROW : _socket(), _monitor_socket()
@@ -2024,8 +2007,7 @@ constexpr event_flags operator~(event_flags a) noexcept
 struct no_user_data;
 
 // layout compatible with zmq_poller_event_t
-template<class T = no_user_data>
-struct poller_event
+template<class T = no_user_data> struct poller_event
 {
     socket_ref socket;
 #ifdef _WIN32
@@ -2114,8 +2096,8 @@ template<typename T = no_user_data> class poller_t
     void add_impl(zmq::socket_ref socket, event_flags events, T *user_data)
     {
         if (0
-            != zmq_poller_add(poller_ptr.get(), socket.handle(),
-                              user_data, static_cast<short>(events))) {
+            != zmq_poller_add(poller_ptr.get(), socket.handle(), user_data,
+                              static_cast<short>(events))) {
             throw error_t();
         }
     }


### PR DESCRIPTION
We have a .clang-format file but over the past 1.5 years several deviations from the defined formatting have evolved. This reformats all files with clang-format to reestablish consistent formatting.