### PR TITLE
Problem: Macros not defined in older versions 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
     # GCC default, draft disabled, default libzmq (defined in ci_build.sh)
     - os: linux
 
-    # GCC 6, draft disabled (default), latest libzmq (default)
+    # GCC 6, draft disabled (default), older libzmq
     - os: linux
       addons:
         apt:
@@ -58,7 +58,7 @@ matrix:
           packages:
             - g++-6
       env:
-        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+        - ZMQ_VERSION=4.2.0 MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
     # GCC 4.9, draft disabled (default), latest libzmq (default)
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
           packages:
             - g++-6
       env:
-        - ZMQ_VERSION=4.2.0 MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+        - ZMQ_VERSION=4.2.5 MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
     # GCC 4.9, draft disabled (default), latest libzmq (default)
     - os: linux

--- a/tests/context.cpp
+++ b/tests/context.cpp
@@ -67,9 +67,11 @@ TEST_CASE("context - use socket after shutdown", "[context]")
 TEST_CASE("context set/get options", "[context]")
 {
     zmq::context_t context;
+#if defined(ZMQ_BLOCKY) && defined(ZMQ_IO_THREADS)
     context.set(zmq::ctxopt::blocky, false);
     context.set(zmq::ctxopt::io_threads, 5);
     CHECK(context.get(zmq::ctxopt::io_threads) == 5);
+#endif
 
     CHECK_THROWS_AS(
         context.set(static_cast<zmq::ctxopt>(-42), 5),

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -635,21 +635,45 @@ inline void swap(message_t &a, message_t &b) ZMQ_NOTHROW
 #ifdef ZMQ_CPP11
 enum class ctxopt
 {
+#ifdef ZMQ_BLOCKY
     blocky = ZMQ_BLOCKY,
+#endif
+#ifdef ZMQ_IO_THREADS
     io_threads = ZMQ_IO_THREADS,
+#endif
+#ifdef ZMQ_THREAD_SCHED_POLICY
     thread_sched_policy = ZMQ_THREAD_SCHED_POLICY,
+#endif
+#ifdef ZMQ_THREAD_PRIORITY
     thread_priority = ZMQ_THREAD_PRIORITY,
+#endif
+#ifdef ZMQ_THREAD_AFFINITY_CPU_ADD
     thread_affinity_cpu_add = ZMQ_THREAD_AFFINITY_CPU_ADD,
+#endif
+#ifdef ZMQ_THREAD_AFFINITY_CPU_REMOVE
     thread_affinity_cpu_remove = ZMQ_THREAD_AFFINITY_CPU_REMOVE,
+#endif
+#ifdef ZMQ_THREAD_NAME_PREFIX
     thread_name_prefix = ZMQ_THREAD_NAME_PREFIX,
+#endif
+#ifdef ZMQ_MAX_MSGSZ
     max_msgsz = ZMQ_MAX_MSGSZ,
+#endif
 #ifdef ZMQ_ZERO_COPY_RECV
     zero_copy_recv = ZMQ_ZERO_COPY_RECV,
 #endif
+#ifdef ZMQ_MAX_SOCKETS
     max_sockets = ZMQ_MAX_SOCKETS,
+#endif
+#ifdef ZMQ_SOCKET_LIMIT
     socket_limit = ZMQ_SOCKET_LIMIT,
+#endif
+#ifdef ZMQ_IPV6
     ipv6 = ZMQ_IPV6,
+#endif
+#ifdef ZMQ_MSG_T_SIZE
     msg_t_size = ZMQ_MSG_T_SIZE
+#endif
 };
 #endif
 


### PR DESCRIPTION
Solution: Guard usage of libzmq macros

Fixes https://github.com/zeromq/cppzmq/issues/385