### PR TITLE
Problem: cppzmq lacks CZMQ compatible 'encode/decode' and 'actor'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # Build directory
 *build/
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ message(STATUS "cppzmq v${cppzmq_VERSION}")
 set(CPPZMQ_HEADERS
     zmq.hpp
     zmq_addon.hpp
+    zmq_actor.hpp
 )
 
 foreach (target cppzmq cppzmq-static)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
     send_multipart.cpp
     monitor.cpp
     utilities.cpp
+    actor.cpp
 )
 
 add_dependencies(unit_tests catch)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(Threads)
 
 add_executable(
     unit_tests
+    actor.cpp
     buffer.cpp
     message.cpp
     context.cpp
@@ -29,7 +30,6 @@ add_executable(
     send_multipart.cpp
     monitor.cpp
     utilities.cpp
-    actor.cpp
 )
 
 add_dependencies(unit_tests catch)

--- a/tests/actor.cpp
+++ b/tests/actor.cpp
@@ -28,12 +28,11 @@ TEST_CASE("actor external and internal termination", "[actor]")
         zmq::actor_t actor(context, myactor, "hello world", false);
         actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);
     }
+}
 
-// }
-
-// TEST_CASE("actor internal termination", "[actor]")
-// {
-//     zmq::context_t context;
+TEST_CASE("actor internal termination", "[actor]")
+{
+    zmq::context_t context;
     {
         zmq::actor_t actor(context, myactor, "fast exit", true);
         actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);

--- a/tests/actor.cpp
+++ b/tests/actor.cpp
@@ -21,7 +21,7 @@ void myactor(zmq::socket_t& pipe, std::string greeting, bool fast_exit)
 }
 
 
-TEST_CASE("actor external termination", "[actor]")
+TEST_CASE("actor external and internal termination", "[actor]")
 {
     zmq::context_t context;
     {
@@ -29,11 +29,11 @@ TEST_CASE("actor external termination", "[actor]")
         actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);
     }
 
-}
+// }
 
-TEST_CASE("actor internal termination", "[actor]")
-{
-    zmq::context_t context;
+// TEST_CASE("actor internal termination", "[actor]")
+// {
+//     zmq::context_t context;
     {
         zmq::actor_t actor(context, myactor, "fast exit", true);
         actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);

--- a/tests/actor.cpp
+++ b/tests/actor.cpp
@@ -1,9 +1,8 @@
 #include <catch.hpp>
-#include <zmq_actor.hpp>
 
+#include <zmq_actor.hpp>
 #ifdef ZMQ_CPP11
 #include <future>
-#endif
 
 #if (__cplusplus >= 201703L)
 static_assert(std::is_nothrow_swappable<zmq::socket_t>::value,
@@ -40,3 +39,5 @@ TEST_CASE("actor internal termination", "[actor]")
         actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);
     }
 }
+
+#endif  // ZMQ_CPP11

--- a/tests/actor.cpp
+++ b/tests/actor.cpp
@@ -1,0 +1,42 @@
+#include <catch.hpp>
+#include <zmq_actor.hpp>
+
+#ifdef ZMQ_CPP11
+#include <future>
+#endif
+
+#if (__cplusplus >= 201703L)
+static_assert(std::is_nothrow_swappable<zmq::socket_t>::value,
+              "socket_t should be nothrow swappable");
+#endif
+
+static
+void myactor(zmq::socket_t& pipe, std::string greeting, bool fast_exit)
+{
+    pipe.send(zmq::message_t{}, zmq::send_flags::none);
+    if (fast_exit) {
+        return;
+    }
+    zmq::message_t rmsg;
+    auto res = pipe.recv(rmsg);
+}
+
+
+TEST_CASE("actor external termination", "[actor]")
+{
+    zmq::context_t context;
+    {
+        zmq::actor_t actor(context, myactor, "hello world", false);
+        actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);
+    }
+
+}
+
+TEST_CASE("actor internal termination", "[actor]")
+{
+    zmq::context_t context;
+    {
+        zmq::actor_t actor(context, myactor, "fast exit", true);
+        actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);
+    }
+}

--- a/zmq_actor.hpp
+++ b/zmq_actor.hpp
@@ -31,6 +31,9 @@
 // Initial implementation uses std::thread so C++11 only.
 #include <thread>
 
+// #include <random>
+#include <iostream>             // debug
+
 namespace zmq {
 
     typedef std::pair<zmq::socket_t, zmq::socket_t> pipe;
@@ -44,12 +47,18 @@ namespace zmq {
         pipe ret{socket_t(ctx, socket_type::pair),
                  socket_t(ctx, socket_type::pair)};
 
+        // std::default_random_engine gen;
+        // std::uniform_int_distribution<int> uni(0,0x10000);
+
         std::stringstream ss;
         ss << "inproc://pipe-"
-           << (void*) ret.first.handle()
+           << std::hex
+           << ret.first.handle()
            << "-"
-           << (void*) ret.second.handle();
+           << ret.second.handle();
+        // ss << "inproc://pipe-" << std::hex << uni(gen) << "-" << uni(gen);
         std::string addr = ss.str();
+        std::cerr << "create_pipe: " << addr << std::endl;
         ret.first.bind(addr.c_str());
         ret.second.connect(addr.c_str());
         return ret;

--- a/zmq_actor.hpp
+++ b/zmq_actor.hpp
@@ -31,9 +31,6 @@
 // Initial implementation uses std::thread so C++11 only.
 #include <thread>
 
-// #include <random>
-#include <iostream>             // debug
-
 namespace zmq {
 
     typedef std::pair<zmq::socket_t, zmq::socket_t> pipe;
@@ -47,18 +44,13 @@ namespace zmq {
         pipe ret{socket_t(ctx, socket_type::pair),
                  socket_t(ctx, socket_type::pair)};
 
-        // std::default_random_engine gen;
-        // std::uniform_int_distribution<int> uni(0,0x10000);
-
         std::stringstream ss;
         ss << "inproc://pipe-"
            << std::hex
            << ret.first.handle()
            << "-"
            << ret.second.handle();
-        // ss << "inproc://pipe-" << std::hex << uni(gen) << "-" << uni(gen);
         std::string addr = ss.str();
-        std::cerr << "create_pipe: " << addr << std::endl;
         ret.first.bind(addr.c_str());
         ret.second.connect(addr.c_str());
         return ret;

--- a/zmq_actor.hpp
+++ b/zmq_actor.hpp
@@ -1,0 +1,116 @@
+/*
+    Copyright (c) 2020 ZeroMQ community
+    Copyright (c) 2020 Brett Viren
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#ifndef __ZMQ_ACTOR_HPP_INCLUDED__
+#define __ZMQ_ACTOR_HPP_INCLUDED__
+
+#include "zmq.hpp"
+#include <thread>
+
+namespace zmq {
+
+    typedef std::pair<zmq::socket_t, zmq::socket_t> pipe;
+
+    /*! Return a pair of PAIR sockets.
+     *
+     * First is bound and second is connected via inproc://
+     */
+    pipe create_pipe(context_t& ctx)
+    {
+        pipe ret{socket_t(ctx, socket_type::pair),
+                 socket_t(ctx, socket_type::pair)};
+
+        std::stringstream ss;
+        ss << "inproc://pipe-"
+           << (void*) ret.first.handle()
+           << "-"
+           << (void*) ret.second.handle();
+        std::string addr = ss.str();
+        ret.first.bind(addr.c_str());
+        ret.second.connect(addr.c_str());
+        return ret;
+    }
+
+
+    // This shim calls the actor function and then provides hard-wired
+    // protocol for shutdown, as per CZMQ zactor_t.
+    // 
+    // fixme: can't figure out how to forward the func nor the args so
+    // we must pass by value only.
+    template<typename Func, typename... Args>
+    void actor_shim(socket_t&& apipe, Func fn, Args... args) {
+        fn(apipe, args...);
+        apipe.send(zmq::message_t{}, zmq::send_flags::none);
+    }
+
+    /*! An CZMQ zactor_t like class.
+     *
+     * Construct it with an actor function and any args.  
+     *
+     * The function will be spawned in a thread.
+     *
+     * Application may use pipe() to communicate with the actor.
+     *
+     * The desctructor will notify and wait for the actor function to
+     * exit, if it is still around.
+     */
+    class actor_t {
+    public:                     // for now for testing
+        socket_t _pipe;
+        std::thread _thread;
+    public:
+
+        template<typename Func, typename... Args>
+        actor_t(context_t& ctx, Func fn, Args... args) {
+            socket_t apipe;
+            std::tie(apipe, _pipe) = create_pipe(ctx);
+                              
+            _thread = std::thread(actor_shim<Func, Args...>,
+                                  std::move(apipe),
+                                  fn,
+                                  args...);
+
+            zmq::message_t rmsg; // wait for actor ready signal
+            auto res = _pipe.recv(rmsg);
+        }
+
+        ~actor_t() {
+            auto sres = _pipe.send(message_t{"$TERM"}, send_flags::dontwait);
+            if (sres) {
+                message_t rmsg;
+                auto res = _pipe.recv(rmsg, recv_flags::none);
+            }
+            _thread.join();
+        }
+
+        socket_t& pipe() { return _pipe; }
+        
+    private:
+        actor_t(const actor_t &) ZMQ_DELETED_FUNCTION;
+        void operator=(const actor_t &) ZMQ_DELETED_FUNCTION;
+
+    };
+    
+}
+
+#endif

--- a/zmq_actor.hpp
+++ b/zmq_actor.hpp
@@ -99,7 +99,7 @@ namespace zmq {
         }
 
         ~actor_t() {
-            auto sres = _pipe.send(message_t{"$TERM"}, send_flags::dontwait);
+            auto sres = _pipe.send(message_t("$TERM",5), send_flags::dontwait);
             if (sres) {
                 message_t rmsg;
                 auto res = _pipe.recv(rmsg, recv_flags::none);

--- a/zmq_actor.hpp
+++ b/zmq_actor.hpp
@@ -25,6 +25,10 @@
 #define __ZMQ_ACTOR_HPP_INCLUDED__
 
 #include "zmq.hpp"
+
+#ifdef ZMQ_CPP11
+// Actor needs some threading.
+// Initial implementation uses std::thread so C++11 only.
 #include <thread>
 
 namespace zmq {
@@ -113,4 +117,5 @@ namespace zmq {
     
 }
 
+#endif
 #endif


### PR DESCRIPTION
This adds methods `encode()` and `decode()` to `multipart_t` which should be compatible with CZMQ's equivalent methods.  In developing the methods I copied CZMQ's code but admit I have not yet actually tried a live cross-code test.  There is a test added in cppzmq so the codec internally round-trips okay.

This PR also adds a new file `zmq_actor.hpp` which is an attempt to make a CZMQ-like actor pattern.  It attempts to copy the shutdown semantics directly from CZMQ.  It uses `std::thread` and has a `.join()` at shutdown which I can't find an equivalent for in CZMQ.  A test is added.  

Hopefully it's okay to bundle these two problems/solutions in one PR.