### PR TITLE
Problem: no actor pattern.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ message(STATUS "cppzmq v${cppzmq_VERSION}")
 set(CPPZMQ_HEADERS
     zmq.hpp
     zmq_addon.hpp
+    zmq_actor.hpp
 )
 
 foreach (target cppzmq cppzmq-static)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(Threads)
 
 add_executable(
     unit_tests
+    actor.cpp
     buffer.cpp
     message.cpp
     context.cpp

--- a/tests/actor.cpp
+++ b/tests/actor.cpp
@@ -1,0 +1,42 @@
+#include <catch.hpp>
+
+#include <zmq_actor.hpp>
+#ifdef ZMQ_CPP11
+#include <future>
+
+#if (__cplusplus >= 201703L)
+static_assert(std::is_nothrow_swappable<zmq::socket_t>::value,
+              "socket_t should be nothrow swappable");
+#endif
+
+static
+void myactor(zmq::socket_t& pipe, std::string greeting, bool fast_exit)
+{
+    pipe.send(zmq::message_t{}, zmq::send_flags::none);
+    if (fast_exit) {
+        return;
+    }
+    zmq::message_t rmsg;
+    auto res = pipe.recv(rmsg);
+}
+
+
+TEST_CASE("actor external and internal termination", "[actor]")
+{
+    zmq::context_t context;
+    {
+        zmq::actor_t actor(context, myactor, "hello world", false);
+        actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);
+    }
+}
+
+TEST_CASE("actor internal termination", "[actor]")
+{
+    zmq::context_t context;
+    {
+        zmq::actor_t actor(context, myactor, "fast exit", true);
+        actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);
+    }
+}
+
+#endif  // ZMQ_CPP11

--- a/tests/actor.cpp
+++ b/tests/actor.cpp
@@ -1,42 +1,125 @@
 #include <catch.hpp>
-
 #include <zmq_actor.hpp>
 #ifdef ZMQ_CPP11
 #include <future>
 
-#if (__cplusplus >= 201703L)
-static_assert(std::is_nothrow_swappable<zmq::socket_t>::value,
-              "socket_t should be nothrow swappable");
-#endif
+
+
+// use to test actor function arg is fully moved
+struct MoveNoCopy {
+    MoveNoCopy() { }
+    MoveNoCopy(MoveNoCopy &&rhs) ZMQ_NOTHROW { }
+    MoveNoCopy &operator=(MoveNoCopy &&rhs) ZMQ_NOTHROW { }
+    MoveNoCopy(const MoveNoCopy &) ZMQ_DELETED_FUNCTION;
+    void operator=(const MoveNoCopy &) ZMQ_DELETED_FUNCTION;
+};
+
 
 static
-void myactor(zmq::socket_t& pipe, std::string greeting, bool fast_exit)
+void czmq_style_actor(zmq::socket_t sock, std::string greeting, bool fast_exit, MoveNoCopy mnc)
 {
-    pipe.send(zmq::message_t{}, zmq::send_flags::none);
+    // CZMQ zactor_t startup protocol requires actor to send a
+    // "signal" signifying "ready".  The app is expected to wait for
+    // this message before continuing with its own processing.
+    sock.send(zmq::message_t{"",1}, zmq::send_flags::none);
+
+    // If true, actor exits before app tells it to.
     if (fast_exit) {
         return;
     }
+
     zmq::message_t rmsg;
-    auto res = pipe.recv(rmsg);
+
+    // This message represents an application protocol implemented in the test.
+    auto res1 = sock.recv(rmsg);
+    CHECK(rmsg.size() == 0);
+
+    // The CZMQ zactor_t shutdown protocol has app sending actor a
+    // terminate message.
+    auto res2 = sock.recv(rmsg);
+    CHECK(rmsg.to_string() == "$TERM");
 }
 
+static
+void noproto_actor(zmq::socket_t sock, std::string greeting, bool fast_exit, MoveNoCopy mnc)
+{
+    // This is a bare cppzmq actor which implements no
+    // startup/shutdown protocol.
 
-TEST_CASE("actor external and internal termination", "[actor]")
+    if (fast_exit) {
+        return;
+    }
+
+    zmq::message_t rmsg;
+    // the test protocol is one payload message.
+    auto res1 = sock.recv(rmsg);
+    CHECK(rmsg.size() == 0);
+
+}
+
+static
+void emulate_czmq(bool fast_exit)
 {
     zmq::context_t context;
     {
-        zmq::actor_t actor(context, myactor, "hello world", false);
-        actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);
+        zmq::actor_t actor(context, czmq_style_actor, "hello world", fast_exit, MoveNoCopy());
+
+        // Recv the CZMQ "actor startup" protocol "ready" message
+        // before continuing.  This is done in the "constructor" of
+        // CZMQ zactor_t.
+        zmq::message_t msg;
+        auto res1 = actor.link().recv(msg); 
+        CHECK(res1);
+        CHECK(msg.size() == 1);
+
+        // When this tests fast_exit=true and the actor function exits
+        // first then socket sends will return false.
+
+        // Send the "test protocol" payload message.
+        auto res2 = actor.link().send(zmq::message_t{}, zmq::send_flags::dontwait);
+        if (!fast_exit) {
+            CHECK(res2.has_value() == true);
+        }
+
+        // Send the CZMQ "actor shutdown" protocol message.  This is
+        // done in the "destructor" of CZMQ zactor_t.
+        auto res3 = actor.link().send(zmq::message_t{"$TERM", 5}, zmq::send_flags::dontwait);
+        if (!fast_exit) {
+            CHECK(res3.has_value() == true);
+        }
     }
 }
+TEST_CASE("actor external termination czmq emulation", "[actor]")
+{
+    emulate_czmq(false);
+}
+TEST_CASE("actor internal termination czmq emulation", "[actor]")
+{
+    emulate_czmq(true);
+}
 
-TEST_CASE("actor internal termination", "[actor]")
+
+static
+void noproto_fastfull(bool fast_exit)
 {
     zmq::context_t context;
     {
-        zmq::actor_t actor(context, myactor, "fast exit", true);
-        actor.pipe().send(zmq::message_t{}, zmq::send_flags::none);
+        zmq::actor_t actor(context, noproto_actor, "hello world", fast_exit, MoveNoCopy());
+        auto res = actor.link().send(zmq::message_t{}, zmq::send_flags::dontwait);
+        for (int i=0; i<100000; ++i) { ; }
+        CHECK(res.has_value() == true);
     }
 }
+
+TEST_CASE("actor external termination cppzmq noproto", "[actor]")
+{
+    noproto_fastfull(false);
+}
+
+TEST_CASE("actor internal termination cppzmq noproto", "[actor]")
+{
+    noproto_fastfull(true);
+}
+
 
 #endif  // ZMQ_CPP11

--- a/zmq_actor.hpp
+++ b/zmq_actor.hpp
@@ -1,0 +1,120 @@
+/*
+    Copyright (c) 2020 ZeroMQ community
+    Copyright (c) 2020 Brett Viren
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#ifndef __ZMQ_ACTOR_HPP_INCLUDED__
+#define __ZMQ_ACTOR_HPP_INCLUDED__
+
+#include "zmq.hpp"
+
+#ifdef ZMQ_CPP11
+// Actor needs some threading.
+// Initial implementation uses std::thread so C++11 only.
+#include <thread>
+
+namespace zmq {
+
+    typedef std::pair<zmq::socket_t, zmq::socket_t> pipe;
+
+    /*! Return a pair of PAIR sockets.
+     *
+     * First is bound and second is connected via inproc://
+     */
+    pipe create_pipe(context_t& ctx)
+    {
+        pipe ret{socket_t(ctx, socket_type::pair),
+                 socket_t(ctx, socket_type::pair)};
+
+        std::stringstream ss;
+        ss << "inproc://pipe-"
+           << std::hex
+           << ret.first.handle()
+           << "-"
+           << ret.second.handle();
+        std::string addr = ss.str();
+        ret.first.bind(addr.c_str());
+        ret.second.connect(addr.c_str());
+        return ret;
+    }
+
+
+    // This shim calls the actor function and then provides hard-wired
+    // protocol for shutdown, mimicking how CZMQ zactor_t does it.
+    template<typename Func, typename... Args>
+    void actor_shim(socket_t&& apipe, Func fn, Args... args) {
+        fn(apipe, args...);
+        apipe.send(zmq::message_t{}, zmq::send_flags::none);
+    }
+
+    /*! An CZMQ zactor_t like class.
+     *
+     * Construct it with an actor function and any args.  
+     *
+     * The function will be spawned in a thread.
+     *
+     * Application may use pipe() for a socket with which to
+     * communicate with the actor.
+     *
+     * The destructor will signal through the pipe and wait for the
+     * actor function to exit, if indeed it is still around.
+     */
+    class actor_t {
+    public:
+
+        template<typename Func, typename... Args>
+        actor_t(context_t& ctx, Func fn, Args... args) {
+            socket_t apipe;
+            std::tie(apipe, _pipe) = create_pipe(ctx);
+                              
+            _thread = std::thread(actor_shim<Func, Args...>,
+                                  std::move(apipe),
+                                  fn,
+                                  args...);
+
+            zmq::message_t rmsg; // wait for actor ready signal
+            auto res = _pipe.recv(rmsg);
+        }
+
+        ~actor_t() {
+            auto sres = _pipe.send(message_t("$TERM",5), send_flags::dontwait);
+            if (sres) {
+                message_t rmsg;
+                auto res = _pipe.recv(rmsg, recv_flags::none);
+            }
+            _thread.join();
+        }
+
+        socket_t& pipe() { return _pipe; }
+        
+    private:
+        actor_t(const actor_t &) ZMQ_DELETED_FUNCTION;
+        void operator=(const actor_t &) ZMQ_DELETED_FUNCTION;
+
+    private:
+        socket_t _pipe;
+        std::thread _thread;
+    };
+    
+}
+
+#endif
+#endif


### PR DESCRIPTION
Solution: provide one which is conceptually similar to CZMQ `zactor_t` in a new and optional header.

This is part of what was initially #388.