### PR TITLE
message_t::to_string now produces the correct string length

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -556,13 +556,17 @@ class message_t
     // interpret message content as a string
     std::string to_string() const
     {
-        return std::string(static_cast<const char *>(data()), size());
+        const auto start = data<const char>();
+        const auto length = std::distance(start, std::find(start, start+size(), '\0'));
+        return std::string(start, length);
     }
 #ifdef ZMQ_CPP17
     // interpret message content as a string
     std::string_view to_string_view() const noexcept
     {
-        return std::string_view(static_cast<const char *>(data()), size());
+        const auto start = data<const char>();
+        const auto length = std::distance(start, std::find(start, start+size(), '\0'));
+        return std::string_view(start, length);
     }
 #endif
 


### PR DESCRIPTION
This fixes the creation of malformed std::strings including or going beyond the cstring null char termination. See https://github.com/zeromq/cppzmq/issues/396

Here is a minimal example reproducing the problem:
```
#include <string>
#include <cstring>
#include <iostream>

using namespace std;

int main() {
  char cstr[128];
  strcpy(cstr, "Hello! How are you?");

  std::string str(cstr, 128);
  cout << str.size() << " --- " << str << endl;

  return 0;
}
```
The output can be:
`128 --- Hello! How are you?PS���T���T�...`

The solution looks first for the terminating null char and then proceeds to copy up to that point. If the null char is not found the whole buffer is copied, as before.