### PR TITLE
Problem: message_t ctor string inconsistency 

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -328,8 +328,8 @@ inline int poll(std::vector<zmq_pollitem_t> &items, long timeout_ = -1)
 }
 
 template<std::size_t SIZE>
-inline int poll(std::array<zmq_pollitem_t, SIZE>& items,
-    std::chrono::milliseconds timeout)
+inline int poll(std::array<zmq_pollitem_t, SIZE> &items,
+                std::chrono::milliseconds timeout)
 {
     return poll(items.data(), items.size(), static_cast<long>(timeout.count()));
 }
@@ -350,13 +350,14 @@ inline std::tuple<int, int, int> version()
 }
 
 #if !defined(ZMQ_CPP11_PARTIAL)
-namespace detail{
+namespace detail
+{
 template<class T> struct is_char_type
 {
     // true if character type for string literals in C++11
     static constexpr bool value =
-      std::is_same<T, char>::value || std::is_same<T, wchar_t>::value ||
-      std::is_same<T, char16_t>::value || std::is_same<T, char32_t>::value;
+      std::is_same<T, char>::value || std::is_same<T, wchar_t>::value
+      || std::is_same<T, char16_t>::value || std::is_same<T, char32_t>::value;
 };
 }
 #endif
@@ -397,8 +398,7 @@ class message_t
         int rc = zmq_msg_init_size(&msg, size_);
         if (rc != 0)
             throw error_t();
-        if (size_)
-        {
+        if (size_) {
             // this constructor allows (nullptr, 0),
             // memcpy with a null pointer is UB
             memcpy(data(), data_, size_);
@@ -418,13 +418,12 @@ class message_t
     // when called with a string literal.
     // An overload taking const char* can not be added because
     // it would be preferred over this function and break compatiblity.
-    template<class Char, size_t N,
-            typename = typename std::enable_if<
-            detail::is_char_type<Char>::value
-            >::type
-            >
-    ZMQ_DEPRECATED(
-        "from 4.7.0, use constructors taking iterators, (pointer, size) or strings instead")
+    template<
+      class Char,
+      size_t N,
+      typename = typename std::enable_if<detail::is_char_type<Char>::value>::type>
+    ZMQ_DEPRECATED("from 4.7.0, use constructors taking iterators, (pointer, size) "
+                   "or strings instead")
     explicit message_t(const Char (&data)[N]) :
         message_t(detail::ranges::begin(data), detail::ranges::end(data))
     {
@@ -441,16 +440,10 @@ class message_t
     {
     }
 
-    explicit message_t(const std::string &str) :
-        message_t(str.data(), str.size())
-    {
-    }
+    explicit message_t(const std::string &str) : message_t(str.data(), str.size()) {}
 
 #if CPPZMQ_HAS_STRING_VIEW
-    explicit message_t(std::string_view str) :
-        message_t(str.data(), str.size())
-    {
-    }
+    explicit message_t(std::string_view str) : message_t(str.data(), str.size()) {}
 #endif
 
 #endif
@@ -1367,19 +1360,19 @@ template<int Opt, int NullTerm = 1> struct array_option
 
 #define ZMQ_DEFINE_INTEGRAL_OPT(OPT, NAME, TYPE)                                    \
     using NAME##_t = integral_option<OPT, TYPE, false>;                             \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME {}
 #define ZMQ_DEFINE_INTEGRAL_BOOL_UNIT_OPT(OPT, NAME, TYPE)                          \
     using NAME##_t = integral_option<OPT, TYPE, true>;                              \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME {}
 #define ZMQ_DEFINE_ARRAY_OPT(OPT, NAME)                                             \
     using NAME##_t = array_option<OPT>;                                             \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME {}
 #define ZMQ_DEFINE_ARRAY_OPT_BINARY(OPT, NAME)                                      \
     using NAME##_t = array_option<OPT, 0>;                                          \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME {}
 #define ZMQ_DEFINE_ARRAY_OPT_BIN_OR_Z85(OPT, NAME)                                  \
     using NAME##_t = array_option<OPT, 2>;                                          \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME {}
 
 // duplicate definition from libzmq 4.3.3
 #if defined _WIN32
@@ -2191,7 +2184,6 @@ class socket_t : public detail::socket_base
             throw error_t();
         if (ctxptr == ZMQ_NULLPTR)
             throw error_t();
-
     }
 };
 


### PR DESCRIPTION
Solution: Constructor taking generic ranges including string literals includes the null terminated char in
the message. Deprecate function and add overloads for strings.

This fixes the root cause of a problem observed in https://github.com/zeromq/cppzmq/issues/396 and discussed here https://github.com/zeromq/cppzmq/pull/397