### PR TITLE
Problem: UB in message_t constructor

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -365,7 +365,12 @@ class message_t
         int rc = zmq_msg_init_size(&msg, size_);
         if (rc != 0)
             throw error_t();
-        memcpy(data(), data_, size_);
+        if (size_)
+        {
+            // this constructor allows (nullptr, 0),
+            // memcpy with a null pointer is UB
+            memcpy(data(), data_, size_);
+        }
     }
 
     message_t(void *data_, size_t size_, free_fn *ffn_, void *hint_ = ZMQ_NULLPTR)


### PR DESCRIPTION
Solution: Add check to guard against passing null to memcpy