### PR TITLE
Problem: Active poller double add mutates handler

### DIFF
--- a/tests/active_poller.cpp
+++ b/tests/active_poller.cpp
@@ -14,9 +14,9 @@ TEST_CASE("create destroy", "[active_poller]")
 }
 
 static_assert(!std::is_copy_constructible<zmq::active_poller_t>::value,
-    "active_active_poller_t should not be copy-constructible");
+              "active_active_poller_t should not be copy-constructible");
 static_assert(!std::is_copy_assignable<zmq::active_poller_t>::value,
-    "active_active_poller_t should not be copy-assignable");
+              "active_active_poller_t should not be copy-assignable");
 
 TEST_CASE("move construct empty", "[active_poller]")
 {
@@ -47,9 +47,7 @@ TEST_CASE("move construct non empty", "[active_poller]")
     zmq::socket_t socket{context, zmq::socket_type::router};
 
     zmq::active_poller_t a;
-    a.add(socket, zmq::event_flags::pollin, [](zmq::event_flags)
-    {
-    });
+    a.add(socket, zmq::event_flags::pollin, [](zmq::event_flags) {});
     CHECK_FALSE(a.empty());
     CHECK(1u == a.size());
     zmq::active_poller_t b = std::move(a);
@@ -65,9 +63,7 @@ TEST_CASE("move assign non empty", "[active_poller]")
     zmq::socket_t socket{context, zmq::socket_type::router};
 
     zmq::active_poller_t a;
-    a.add(socket, zmq::event_flags::pollin, [](zmq::event_flags)
-    {
-    });
+    a.add(socket, zmq::event_flags::pollin, [](zmq::event_flags) {});
     CHECK_FALSE(a.empty());
     CHECK(1u == a.size());
     zmq::active_poller_t b;
@@ -97,8 +93,9 @@ TEST_CASE("add handler invalid events type", "[active_poller]")
     zmq::active_poller_t::handler_type handler;
     short invalid_events_type = 2 << 10;
     CHECK_THROWS_AS(
-        active_poller.add(socket, static_cast<zmq::event_flags>(invalid_events_type),
-            handler), const zmq::error_t&);
+      active_poller.add(socket, static_cast<zmq::event_flags>(invalid_events_type),
+                        handler),
+      const zmq::error_t &);
     CHECK(active_poller.empty());
     CHECK(0u == active_poller.size());
 }
@@ -113,7 +110,7 @@ TEST_CASE("add handler twice throws", "[active_poller]")
     active_poller.add(socket, zmq::event_flags::pollin, handler);
     /// \todo the actual error code should be checked
     CHECK_THROWS_AS(active_poller.add(socket, zmq::event_flags::pollin, handler),
-                    const zmq::error_t&);
+                    const zmq::error_t &);
 }
 
 TEST_CASE("wait with no handlers throws", "[active_poller]")
@@ -121,7 +118,7 @@ TEST_CASE("wait with no handlers throws", "[active_poller]")
     zmq::active_poller_t active_poller;
     /// \todo the actual error code should be checked
     CHECK_THROWS_AS(active_poller.wait(std::chrono::milliseconds{10}),
-                    const zmq::error_t&);
+                    const zmq::error_t &);
 }
 
 TEST_CASE("remove unregistered throws", "[active_poller]")
@@ -130,7 +127,7 @@ TEST_CASE("remove unregistered throws", "[active_poller]")
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(active_poller.remove(socket), const zmq::error_t&);
+    CHECK_THROWS_AS(active_poller.remove(socket), const zmq::error_t &);
 }
 
 TEST_CASE("remove registered empty", "[active_poller]")
@@ -148,9 +145,7 @@ TEST_CASE("remove registered non empty", "[active_poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
-    active_poller.add(socket, zmq::event_flags::pollin, [](zmq::event_flags)
-    {
-    });
+    active_poller.add(socket, zmq::event_flags::pollin, [](zmq::event_flags) {});
     CHECK_NOTHROW(active_poller.remove(socket));
 }
 
@@ -158,8 +153,7 @@ namespace
 {
 struct server_client_setup : common_server_client_setup
 {
-    zmq::active_poller_t::handler_type handler = [&](zmq::event_flags e)
-    {
+    zmq::active_poller_t::handler_type handler = [&](zmq::event_flags e) {
         events = e;
     };
 
@@ -178,12 +172,11 @@ TEST_CASE("poll basic", "[active_poller]")
 
     zmq::active_poller_t active_poller;
     bool message_received = false;
-    zmq::active_poller_t::handler_type handler = [&message_received
-        ](zmq::event_flags events)
-    {
-        CHECK(zmq::event_flags::none != (events & zmq::event_flags::pollin));
-        message_received = true;
-    };
+    zmq::active_poller_t::handler_type handler =
+      [&message_received](zmq::event_flags events) {
+          CHECK(zmq::event_flags::none != (events & zmq::event_flags::pollin));
+          message_received = true;
+      };
     CHECK_NOTHROW(active_poller.add(s.server, zmq::event_flags::pollin, handler));
     CHECK(1 == active_poller.wait(std::chrono::milliseconds{-1}));
     CHECK(message_received);
@@ -200,8 +193,7 @@ TEST_CASE("client server", "[active_poller]")
     // Setup active_poller
     zmq::active_poller_t active_poller;
     zmq::event_flags events;
-    zmq::active_poller_t::handler_type handler = [&](zmq::event_flags e)
-    {
+    zmq::active_poller_t::handler_type handler = [&](zmq::event_flags e) {
         if (zmq::event_flags::none != (e & zmq::event_flags::pollin)) {
             zmq::message_t zmq_msg;
             CHECK_NOTHROW(s.server.recv(zmq_msg)); // get message
@@ -224,9 +216,8 @@ TEST_CASE("client server", "[active_poller]")
 
     // Re-add server socket with pollout flag
     CHECK_NOTHROW(active_poller.remove(s.server));
-    CHECK_NOTHROW(
-        active_poller.add(s.server, zmq::event_flags::pollin | zmq::event_flags::
-            pollout, handler));
+    CHECK_NOTHROW(active_poller.add(
+      s.server, zmq::event_flags::pollin | zmq::event_flags::pollout, handler));
     CHECK(1 == active_poller.wait(std::chrono::milliseconds{-1}));
     CHECK(events == zmq::event_flags::pollout);
 }
@@ -237,10 +228,9 @@ TEST_CASE("add invalid socket throws", "[active_poller]")
     zmq::active_poller_t active_poller;
     zmq::socket_t a{context, zmq::socket_type::router};
     zmq::socket_t b{std::move(a)};
-    CHECK_THROWS_AS(
-        active_poller.add(a, zmq::event_flags::pollin, zmq::active_poller_t::
-            handler_type{}),
-        const zmq::error_t&);
+    CHECK_THROWS_AS(active_poller.add(a, zmq::event_flags::pollin,
+                                      zmq::active_poller_t::handler_type{}),
+                    const zmq::error_t &);
 }
 
 TEST_CASE("remove invalid socket throws", "[active_poller]")
@@ -248,13 +238,12 @@ TEST_CASE("remove invalid socket throws", "[active_poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
-    CHECK_NOTHROW(
-        active_poller.add(socket, zmq::event_flags::pollin, zmq::active_poller_t::
-            handler_type{}));
+    CHECK_NOTHROW(active_poller.add(socket, zmq::event_flags::pollin,
+                                    zmq::active_poller_t::handler_type{}));
     CHECK(1u == active_poller.size());
     std::vector<zmq::socket_t> sockets;
     sockets.emplace_back(std::move(socket));
-    CHECK_THROWS_AS(active_poller.remove(socket), const zmq::error_t&);
+    CHECK_THROWS_AS(active_poller.remove(socket), const zmq::error_t &);
     CHECK(1u == active_poller.size());
 }
 
@@ -274,7 +263,7 @@ TEST_CASE("modify empty throws", "[active_poller]")
     zmq::socket_t socket{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
     CHECK_THROWS_AS(active_poller.modify(socket, zmq::event_flags::pollin),
-                    const zmq::error_t&);
+                    const zmq::error_t &);
 }
 
 TEST_CASE("modify invalid socket throws", "[active_poller]")
@@ -284,7 +273,7 @@ TEST_CASE("modify invalid socket throws", "[active_poller]")
     zmq::socket_t b{std::move(a)};
     zmq::active_poller_t active_poller;
     CHECK_THROWS_AS(active_poller.modify(a, zmq::event_flags::pollin),
-                    const zmq::error_t&);
+                    const zmq::error_t &);
 }
 
 TEST_CASE("modify not added throws", "[active_poller]")
@@ -293,11 +282,10 @@ TEST_CASE("modify not added throws", "[active_poller]")
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::socket_t b{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
-    CHECK_NOTHROW(
-        active_poller.add(a, zmq::event_flags::pollin, zmq::active_poller_t::
-            handler_type{}));
+    CHECK_NOTHROW(active_poller.add(a, zmq::event_flags::pollin,
+                                    zmq::active_poller_t::handler_type{}));
     CHECK_THROWS_AS(active_poller.modify(b, zmq::event_flags::pollin),
-                    const zmq::error_t&);
+                    const zmq::error_t &);
 }
 
 TEST_CASE("modify simple", "[active_poller]")
@@ -305,12 +293,10 @@ TEST_CASE("modify simple", "[active_poller]")
     zmq::context_t context;
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
+    CHECK_NOTHROW(active_poller.add(a, zmq::event_flags::pollin,
+                                    zmq::active_poller_t::handler_type{}));
     CHECK_NOTHROW(
-        active_poller.add(a, zmq::event_flags::pollin, zmq::active_poller_t::
-            handler_type{}));
-    CHECK_NOTHROW(
-        active_poller.modify(a, zmq::event_flags::pollin | zmq::event_flags::pollout
-        ));
+      active_poller.modify(a, zmq::event_flags::pollin | zmq::event_flags::pollout));
 }
 
 TEST_CASE("poll client server", "[active_poller]")
@@ -330,9 +316,8 @@ TEST_CASE("poll client server", "[active_poller]")
     CHECK(s.events == zmq::event_flags::pollin);
 
     // Modify server socket with pollout flag
-    CHECK_NOTHROW(
-        active_poller.modify(s.server, zmq::event_flags::pollin | zmq::event_flags::
-            pollout));
+    CHECK_NOTHROW(active_poller.modify(s.server, zmq::event_flags::pollin
+                                                   | zmq::event_flags::pollout));
     CHECK(1 == active_poller.wait(std::chrono::milliseconds{500}));
     CHECK(s.events == (zmq::event_flags::pollin | zmq::event_flags::pollout));
 }
@@ -346,9 +331,8 @@ TEST_CASE("wait one return", "[active_poller]")
 
     // Setup active_poller
     zmq::active_poller_t active_poller;
-    CHECK_NOTHROW(
-        active_poller.add(s.server, zmq::event_flags::pollin, [&count](zmq::
-            event_flags) { ++count; }));
+    CHECK_NOTHROW(active_poller.add(s.server, zmq::event_flags::pollin,
+                                    [&count](zmq::event_flags) { ++count; }));
 
     // client sends message
     CHECK_NOTHROW(s.client.send(zmq::message_t{hi_str}, zmq::send_flags::none));
@@ -368,7 +352,7 @@ TEST_CASE("wait on move constructed active_poller", "[active_poller]")
     zmq::active_poller_t b{std::move(a)};
     CHECK(1u == b.size());
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(a.wait(std::chrono::milliseconds{10}), const zmq::error_t&);
+    CHECK_THROWS_AS(a.wait(std::chrono::milliseconds{10}), const zmq::error_t &);
     CHECK(b.wait(std::chrono::milliseconds{-1}));
 }
 
@@ -383,7 +367,7 @@ TEST_CASE("wait on move assigned active_poller", "[active_poller]")
     b = {std::move(a)};
     CHECK(1u == b.size());
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(a.wait(std::chrono::milliseconds{10}), const zmq::error_t&);
+    CHECK_THROWS_AS(a.wait(std::chrono::milliseconds{10}), const zmq::error_t &);
     CHECK(b.wait(std::chrono::milliseconds{-1}));
 }
 
@@ -394,9 +378,8 @@ TEST_CASE("received on move constructed active_poller", "[active_poller]")
     int count = 0;
     // Setup active_poller a
     zmq::active_poller_t a;
-    CHECK_NOTHROW(
-        a.add(s.server, zmq::event_flags::pollin, [&count](zmq::event_flags) { ++
-            count; }));
+    CHECK_NOTHROW(a.add(s.server, zmq::event_flags::pollin,
+                        [&count](zmq::event_flags) { ++count; }));
     // client sends message
     CHECK_NOTHROW(s.client.send(zmq::message_t{hi_str}, zmq::send_flags::none));
     // wait for message and verify it is received
@@ -425,13 +408,13 @@ TEST_CASE("remove from handler", "[active_poller]")
     zmq::active_poller_t active_poller;
     int count = 0;
     for (size_t i = 0; i < ITER_NO; ++i) {
-        CHECK_NOTHROW(
-            active_poller.add(setup_list[i].server, zmq::event_flags::pollin, [&, i](
-                    zmq::event_flags events) {
-                CHECK(events == zmq::event_flags::pollin);
-                active_poller.remove(setup_list[ITER_NO - i - 1].server);
-                CHECK((ITER_NO - i - 1) == active_poller.size());
-                }));
+        CHECK_NOTHROW(active_poller.add(
+          setup_list[i].server, zmq::event_flags::pollin,
+          [&, i](zmq::event_flags events) {
+              CHECK(events == zmq::event_flags::pollin);
+              active_poller.remove(setup_list[ITER_NO - i - 1].server);
+              CHECK((ITER_NO - i - 1) == active_poller.size());
+          }));
         ++count;
     }
     CHECK(ITER_NO == active_poller.size());

--- a/tests/active_poller.cpp
+++ b/tests/active_poller.cpp
@@ -108,17 +108,13 @@ TEST_CASE("add handler twice throws", "[active_poller]")
     zmq::active_poller_t active_poller;
     zmq::active_poller_t::handler_type handler;
     active_poller.add(socket, zmq::event_flags::pollin, handler);
-    /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(active_poller.add(socket, zmq::event_flags::pollin, handler),
-                    const zmq::error_t &);
+    CHECK_THROWS_ZMQ_ERROR(EINVAL, active_poller.add(socket, zmq::event_flags::pollin, handler));
 }
 
 TEST_CASE("wait with no handlers throws", "[active_poller]")
 {
     zmq::active_poller_t active_poller;
-    /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(active_poller.wait(std::chrono::milliseconds{10}),
-                    const zmq::error_t &);
+    CHECK_THROWS_ZMQ_ERROR(EFAULT, active_poller.wait(std::chrono::milliseconds{10}));
 }
 
 TEST_CASE("remove unregistered throws", "[active_poller]")
@@ -126,8 +122,7 @@ TEST_CASE("remove unregistered throws", "[active_poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::router};
     zmq::active_poller_t active_poller;
-    /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(active_poller.remove(socket), const zmq::error_t &);
+    CHECK_THROWS_ZMQ_ERROR(EINVAL, active_poller.remove(socket));
 }
 
 TEST_CASE("remove registered empty", "[active_poller]")
@@ -351,8 +346,8 @@ TEST_CASE("wait on move constructed active_poller", "[active_poller]")
     CHECK_NOTHROW(a.add(s.server, zmq::event_flags::pollin, handler));
     zmq::active_poller_t b{std::move(a)};
     CHECK(1u == b.size());
-    /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(a.wait(std::chrono::milliseconds{10}), const zmq::error_t &);
+    CHECK(0u == a.size());
+    CHECK_THROWS_ZMQ_ERROR(EFAULT, a.wait(std::chrono::milliseconds{10}));
     CHECK(b.wait(std::chrono::milliseconds{-1}));
 }
 
@@ -366,8 +361,8 @@ TEST_CASE("wait on move assigned active_poller", "[active_poller]")
     zmq::active_poller_t b;
     b = {std::move(a)};
     CHECK(1u == b.size());
-    /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(a.wait(std::chrono::milliseconds{10}), const zmq::error_t &);
+    CHECK(0u == a.size());
+    CHECK_THROWS_ZMQ_ERROR(EFAULT, a.wait(std::chrono::milliseconds{10}));
     CHECK(b.wait(std::chrono::milliseconds{-1}));
 }
 

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -33,3 +33,22 @@ struct common_server_client_setup
     std::string endpoint;
 };
 #endif
+
+#define CHECK_THROWS_ZMQ_ERROR(ecode, expr)                                         \
+    do {                                                                            \
+        try {                                                                       \
+            expr;                                                                   \
+            CHECK(false);                                                           \
+        }                                                                           \
+        catch (const zmq::error_t &ze) {                                            \
+            INFO(std::string("Unexpected error code: ") + ze.what());               \
+            CHECK(ze.num() == ecode);                                               \
+        }                                                                           \
+        catch (const std::exception &ex) {                                          \
+            INFO(std::string("Unexpected exception: ") + ex.what());                \
+            CHECK(false);                                                           \
+        }                                                                           \
+        catch (...) {                                                               \
+            CHECK(false);                                                           \
+        }                                                                           \
+    } while (false)

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -250,12 +250,13 @@ typedef zmq_pollitem_t pollitem_t;
 class error_t : public std::exception
 {
   public:
-    error_t() : errnum(zmq_errno()) {}
+    error_t() ZMQ_NOTHROW : errnum(zmq_errno()) {}
+    explicit error_t(int err) ZMQ_NOTHROW : errnum(err) {}
     virtual const char *what() const ZMQ_NOTHROW ZMQ_OVERRIDE
     {
         return zmq_strerror(errnum);
     }
-    int num() const { return errnum; }
+    int num() const ZMQ_NOTHROW { return errnum; }
 
   private:
     int errnum;

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -675,20 +675,17 @@ class active_poller_t
     {
         if (!handler)
             throw std::invalid_argument("null handler in active_poller_t::add");
-        auto it = decltype(handlers)::iterator{};
-        auto inserted = bool{};
-        std::tie(it, inserted) = handlers.emplace(
+        auto ret = handlers.emplace(
           socket, std::make_shared<handler_type>(std::move(handler)));
+        if (!ret.second)
+            throw error_t(EINVAL); // already added
         try {
-            base_poller.add(socket, events,
-                            inserted && *(it->second) ? it->second.get() : nullptr);
-            need_rebuild |= inserted;
+            base_poller.add(socket, events, ret.first->second.get());
+            need_rebuild = true;
         }
-        catch (const zmq::error_t &) {
+        catch (...) {
             // rollback
-            if (inserted) {
-                handlers.erase(socket);
-            }
+            handlers.erase(socket);
             throw;
         }
     }
@@ -720,8 +717,8 @@ class active_poller_t
         std::for_each(poller_events.begin(),
                       poller_events.begin() + static_cast<ptrdiff_t>(count),
                       [](decltype(base_poller)::event_type &event) {
-                          if (event.user_data != nullptr)
-                              (*event.user_data)(event.events);
+                          assert(event.user_data != nullptr);
+                          (*event.user_data)(event.events);
                       });
         return count;
     }

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -673,6 +673,8 @@ class active_poller_t
 
     void add(zmq::socket_ref socket, event_flags events, handler_type handler)
     {
+        if (!handler)
+            throw std::invalid_argument("null handler in active_poller_t::add");
         auto it = decltype(handlers)::iterator{};
         auto inserted = bool{};
         std::tie(it, inserted) = handlers.emplace(


### PR DESCRIPTION
Solution: Check if socket already added before storing.
Add requirement that the handler is non-null. Improve
checks for zmq error codes.