### PR TITLE
Fix error: default initialization of an object of const type

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1296,19 +1296,19 @@ template<int Opt, int NullTerm = 1> struct array_option
 
 #define ZMQ_DEFINE_INTEGRAL_OPT(OPT, NAME, TYPE)                                    \
     using NAME##_t = integral_option<OPT, TYPE, false>;                             \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
 #define ZMQ_DEFINE_INTEGRAL_BOOL_UNIT_OPT(OPT, NAME, TYPE)                          \
     using NAME##_t = integral_option<OPT, TYPE, true>;                              \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
 #define ZMQ_DEFINE_ARRAY_OPT(OPT, NAME)                                             \
     using NAME##_t = array_option<OPT>;                                             \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
 #define ZMQ_DEFINE_ARRAY_OPT_BINARY(OPT, NAME)                                      \
     using NAME##_t = array_option<OPT, 0>;                                          \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
 #define ZMQ_DEFINE_ARRAY_OPT_BIN_OR_Z85(OPT, NAME)                                  \
     using NAME##_t = array_option<OPT, 2>;                                          \
-    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME
+    ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME{}
 
 // duplicate definition from libzmq 4.3.3
 #if defined _WIN32


### PR DESCRIPTION
This commit fixes a regression introduced in a3e5b54c3 (Problem: Socket
options lack type-safety (#393)).

It addresses the following error reported when building the project
on macOS 10.11.6.

Errors like the following:

```
  cppzmq/zmq.hpp:1325:39: error: default initialization of an object of const type 'const affinity_t' (aka 'const integral_option<4, unsigned long long, false>') without a user-provided default constructor
```

Compiler version:

```
  Apple LLVM version 8.0.0 (clang-800.0.42.1)
  Target: x86_64-apple-darwin15.6.0
  Thread model: posix
  InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

Similar issues:

 * https://github.com/tensorflow/tensorflow/issues/28839
  error: default initialization of an object of const type 'const Subgraph::Identity' without a user-provided default constructor

 * https://bugzilla.mozilla.org/show_bug.cgi?id=1451088
   Clang 3.8: error: default initialization of an object of const type 'const js::jit::ArithPolicy' without a user-provided default constructor

 * https://github.com/googleapis/google-cloud-cpp/issues/1593
   [osx] error: default initialization of an object of const type