### PR TITLE
Feat/monitor poll

### DIFF
--- a/tests/monitor.cpp
+++ b/tests/monitor.cpp
@@ -156,6 +156,24 @@ TEST_CASE("monitor init get event count", "[monitor]")
         }
     }
 
+    SECTION("poller_t get_event")
+    {
+        zmq::poller_t<> poller;
+        CHECK_NOTHROW(poller.add(monitor, zmq::event_flags::pollin));
+
+        while (total < expected_event_count)
+        {
+            std::vector<zmq::poller_event<>> events(1);
+            if(0 == poller.wait_all(events, std::chrono::milliseconds{ 100 }))
+                continue;
+
+            CHECK(zmq::event_flags::pollin == events[0].events);
+            CHECK(monitor.get_event(eventMsg, address));
+
+            lbd_count_event(eventMsg);
+        }
+    }
+
     CHECK(connect_delayed == 1);
     CHECK(connected == 1);
     CHECK(total == expected_event_count);

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -2414,6 +2414,15 @@ class monitor_t
         _socket = socket_ref();
     }
 #endif
+
+    void close() ZMQ_NOTHROW
+    {
+#ifdef ZMQ_EVENT_MONITOR_STOPPED
+        abort();
+#endif
+        _monitor_socket = socket_t();
+    }
+
     virtual void on_monitor_started() {}
     virtual void on_event_connected(const zmq_event_t &event_, const char *addr_)
     {
@@ -2518,13 +2527,6 @@ class monitor_t
 
     socket_ref _socket;
     socket_t _monitor_socket;
-
-    void close() ZMQ_NOTHROW
-    {
-        if (_socket)
-            zmq_socket_monitor(_socket.handle(), ZMQ_NULLPTR, 0);
-        _monitor_socket.close();
-    }
 };
 
 #if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11) && defined(ZMQ_HAVE_POLLER)

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -2232,6 +2232,8 @@ class monitor_t
 
     ZMQ_NODISCARD const void *handle() const ZMQ_NOTHROW { return _monitor_socket.handle(); }
 
+    operator socket_ref() ZMQ_NOTHROW { return (zmq::socket_ref) _monitor_socket; }
+
 #if ZMQ_VERSION_MAJOR >= 4
     bool get_event(zmq_event_t& eventMsg, std::string& address, zmq::recv_flags flags = zmq::recv_flags::none)
     {

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -2224,6 +2224,14 @@ class monitor_t
         on_monitor_started();
     }
 
+    operator void *() ZMQ_NOTHROW { return handle(); }
+
+    operator void const *() const ZMQ_NOTHROW { return handle(); }
+
+    ZMQ_NODISCARD void *handle() ZMQ_NOTHROW { return _monitor_socket.handle(); }
+
+    ZMQ_NODISCARD const void *handle() const ZMQ_NOTHROW { return _monitor_socket.handle(); }
+
 #if ZMQ_VERSION_MAJOR >= 4
     bool get_event(zmq_event_t& eventMsg, std::string& address, zmq::recv_flags flags = zmq::recv_flags::none)
     {


### PR DESCRIPTION
This MR improve monitor_t class by addressing #381 and #109.

This lead to better application design and allows the same thread to do both monitoring and retrieving messages from the monitored socket, thus avoiding clunky code with threads joining everywhere.