### PR TITLE
Fix VS 2015 syntax error with macro

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -61,7 +61,7 @@
 #define ZMQ_CPP17
 #endif
 
-#if defined(ZMQ_CPP14)
+#if defined(ZMQ_CPP14) && !defined(_MSC_VER)
 #define ZMQ_DEPRECATED(msg) [[deprecated(msg)]]
 #elif defined(_MSC_VER)
 #define ZMQ_DEPRECATED(msg) __declspec(deprecated(msg))


### PR DESCRIPTION
Fixes #446 

It turns out that the use of the deprecation macro before this constructor does not play well with vs2015.

This was introduced at the last commit before the release.