### PR TITLE
Problem: zmq_fd_t not used/available in zmq

### DIFF
--- a/tests/socket.cpp
+++ b/tests/socket.cpp
@@ -270,8 +270,7 @@ TEST_CASE("socket check integral options", "[socket]")
     check_integral_opt_get<int>(zmq::sockopt::events, router, "events");
 #endif
 #ifdef ZMQ_FD
-    check_integral_opt_get<zmq::sockopt::cppzmq_fd_t>(zmq::sockopt::fd, router,
-                                                      "fd");
+    check_integral_opt_get<zmq::fd_t>(zmq::sockopt::fd, router, "fd");
 #endif
 #ifdef ZMQ_HANDSHAKE_IVL
     check_integral_opt<int>(zmq::sockopt::handshake_ivl, router, "handshake_ivl");

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1395,7 +1395,8 @@ template<int Opt, int NullTerm = 1> struct array_option
     using NAME##_t = array_option<OPT, 2>;                                          \
     ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME {}
 
-using cppzmq_fd_t ZMQ_DEPRECATED("use zmq::fd_t") = ::zmq::fd_t;
+// deprecated, use zmq::fd_t
+using cppzmq_fd_t = ::zmq::fd_t;
 
 #ifdef ZMQ_AFFINITY
 ZMQ_DEFINE_INTEGRAL_OPT(ZMQ_AFFINITY, affinity, uint64_t);

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -271,6 +271,17 @@ struct is_range<
 typedef zmq_free_fn free_fn;
 typedef zmq_pollitem_t pollitem_t;
 
+// duplicate definition from libzmq 4.3.3
+#if defined _WIN32
+#if defined _WIN64
+typedef unsigned __int64 fd_t;
+#else
+typedef unsigned int fd_t;
+#endif
+#else
+typedef int fd_t;
+#endif
+
 class error_t : public std::exception
 {
   public:
@@ -1349,10 +1360,6 @@ constexpr const_buffer operator"" _zbuf(const char32_t *str, size_t len) noexcep
 }
 }
 
-#endif // ZMQ_CPP11
-
-
-#ifdef ZMQ_CPP11
 namespace sockopt
 {
 // There are two types of options,
@@ -1388,16 +1395,7 @@ template<int Opt, int NullTerm = 1> struct array_option
     using NAME##_t = array_option<OPT, 2>;                                          \
     ZMQ_INLINE_VAR ZMQ_CONSTEXPR_VAR NAME##_t NAME {}
 
-// duplicate definition from libzmq 4.3.3
-#if defined _WIN32
-#if defined _WIN64
-typedef unsigned __int64 cppzmq_fd_t;
-#else
-typedef unsigned int cppzmq_fd_t;
-#endif
-#else
-typedef int cppzmq_fd_t;
-#endif
+using cppzmq_fd_t ZMQ_DEPRECATED("use zmq::fd_t") = ::zmq::fd_t;
 
 #ifdef ZMQ_AFFINITY
 ZMQ_DEFINE_INTEGRAL_OPT(ZMQ_AFFINITY, affinity, uint64_t);
@@ -1433,7 +1431,7 @@ ZMQ_DEFINE_ARRAY_OPT_BIN_OR_Z85(ZMQ_CURVE_SERVERKEY, curve_serverkey);
 ZMQ_DEFINE_INTEGRAL_OPT(ZMQ_EVENTS, events, int);
 #endif
 #ifdef ZMQ_FD
-ZMQ_DEFINE_INTEGRAL_OPT(ZMQ_FD, fd, cppzmq_fd_t);
+ZMQ_DEFINE_INTEGRAL_OPT(ZMQ_FD, fd, ::zmq::fd_t);
 #endif
 #ifdef ZMQ_GSSAPI_PLAINTEXT
 ZMQ_DEFINE_INTEGRAL_BOOL_UNIT_OPT(ZMQ_GSSAPI_PLAINTEXT, gssapi_plaintext, int);
@@ -2583,11 +2581,7 @@ struct no_user_data;
 template<class T = no_user_data> struct poller_event
 {
     socket_ref socket;
-#ifdef _WIN32
-    SOCKET fd;
-#else
-    int fd;
-#endif
+    ::zmq::fd_t fd;
     T *user_data;
     event_flags events;
 };


### PR DESCRIPTION
Solution: Make zmq::fd_t available and use in poller_event

This is currently available as zmq::sockopt::cppzmq_fd_t, so this is techincally a breaking change. I could add a typedef there for backward compatibility reasons if requested.