### PR TITLE
Problem: if constexpr warnings on MSVC

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -97,8 +97,10 @@
 #endif
 #if defined(ZMQ_CPP17)
 #define ZMQ_INLINE_VAR inline
+#define ZMQ_CONSTEXPR_IF constexpr
 #else
 #define ZMQ_INLINE_VAR
+#define ZMQ_CONSTEXPR_IF
 #endif
 
 #include <cassert>
@@ -1769,17 +1771,19 @@ class socket_base
     ZMQ_NODISCARD std::string get(sockopt::array_option<Opt, NullTerm>,
                                   size_t init_size = 1024) const
     {
-        if (NullTerm == 2 && init_size == 1024) {
-            init_size = 41; // get as Z85 string
+        if ZMQ_CONSTEXPR_IF (NullTerm == 2) {
+            if (init_size == 1024) {
+                init_size = 41; // get as Z85 string
+            }
         }
         std::string str(init_size, '\0');
         size_t size = get(sockopt::array_option<Opt>{}, buffer(str));
-        if (NullTerm == 1) {
+        if ZMQ_CONSTEXPR_IF (NullTerm == 1) {
             if (size > 0) {
                 assert(str[size - 1] == '\0');
                 --size;
             }
-        } else if (NullTerm == 2) {
+        } else if ZMQ_CONSTEXPR_IF (NullTerm == 2) {
             assert(size == 32 || size == 41);
             if (size == 41) {
                 assert(str[size - 1] == '\0');

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -49,7 +49,7 @@ recv_multipart_n(socket_ref s, OutputIt out, size_t n, recv_flags flags)
     size_t msg_count = 0;
     message_t msg;
     while (true) {
-        if (CheckN) {
+        if ZMQ_CONSTEXPR_IF (CheckN) {
             if (msg_count >= n)
                 throw std::runtime_error(
                   "Too many message parts in recv_multipart_n");


### PR DESCRIPTION
Solution: Use if constexpr where possible in C++17