### PR TITLE
Generalize arithmetic operators for socket_base and derived

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -2080,27 +2080,27 @@ inline bool operator!=(std::nullptr_t /*p*/, socket_ref sr) ZMQ_NOTHROW
 }
 #endif
 
-inline bool operator==(socket_ref a, socket_ref b) ZMQ_NOTHROW
+inline bool operator==(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
 {
-    return std::equal_to<void *>()(a.handle(), b.handle());
+    return std::equal_to<const void *>()(a.handle(), b.handle());
 }
-inline bool operator!=(socket_ref a, socket_ref b) ZMQ_NOTHROW
+inline bool operator!=(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
 {
     return !(a == b);
 }
-inline bool operator<(socket_ref a, socket_ref b) ZMQ_NOTHROW
+inline bool operator<(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
 {
-    return std::less<void *>()(a.handle(), b.handle());
+    return std::less<const void *>()(a.handle(), b.handle());
 }
-inline bool operator>(socket_ref a, socket_ref b) ZMQ_NOTHROW
+inline bool operator>(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
 {
     return b < a;
 }
-inline bool operator<=(socket_ref a, socket_ref b) ZMQ_NOTHROW
+inline bool operator<=(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
 {
     return !(a > b);
 }
-inline bool operator>=(socket_ref a, socket_ref b) ZMQ_NOTHROW
+inline bool operator>=(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
 {
     return !(a < b);
 }


### PR DESCRIPTION
Close #469

As mentioned in the issue and the referred comment, this PR is in particular needed for the migration to Catch2, which exposed that these operators were not covering some cases (e.g. `socket_ref` vs `socket_t`).

This generalization is based on polymorphism and improves const correctness, without exploiting custom cast operators of `socket_ref` and `socket_t` (indeed, it is not so clear to me the situation of these conversion functions, and their const correctness).

@gummif has for sure insight on this and may want to give a final feedback on this.