### PR TITLE
Add support for socket_ref to multipart_t ctor/send/recv 

### DIFF
--- a/tests/multipart.cpp
+++ b/tests/multipart.cpp
@@ -1,6 +1,10 @@
 #include <catch.hpp>
 #include <zmq_addon.hpp>
 
+static_assert(std::is_same<decltype(zmq::multipart_t().send(zmq::socket_ref())), bool>::value);
+static_assert(std::is_same<decltype(zmq::multipart_t().recv(zmq::socket_ref())), bool>::value);
+static_assert(std::is_same<decltype(zmq::multipart_t(zmq::socket_ref())), decltype(zmq::multipart_t())>::value);
+
 #ifdef ZMQ_HAS_RVALUE_REFS
 /// \todo split this up into separate test cases
 ///

--- a/tests/multipart.cpp
+++ b/tests/multipart.cpp
@@ -1,11 +1,12 @@
 #include <catch.hpp>
 #include <zmq_addon.hpp>
 
+#ifdef ZMQ_HAS_RVALUE_REFS
+
 static_assert(std::is_same<decltype(zmq::multipart_t().send(zmq::socket_ref())), bool>::value);
 static_assert(std::is_same<decltype(zmq::multipart_t().recv(zmq::socket_ref())), bool>::value);
 static_assert(std::is_same<decltype(zmq::multipart_t(zmq::socket_ref())), decltype(zmq::multipart_t())>::value);
 
-#ifdef ZMQ_HAS_RVALUE_REFS
 /// \todo split this up into separate test cases
 ///
 TEST_CASE("multipart legacy test", "[multipart]")

--- a/tests/multipart.cpp
+++ b/tests/multipart.cpp
@@ -3,9 +3,20 @@
 
 #ifdef ZMQ_HAS_RVALUE_REFS
 
-static_assert(std::is_same<decltype(zmq::multipart_t().send(zmq::socket_ref())), bool>::value);
-static_assert(std::is_same<decltype(zmq::multipart_t().recv(zmq::socket_ref())), bool>::value);
-static_assert(std::is_same<decltype(zmq::multipart_t(zmq::socket_ref())), decltype(zmq::multipart_t())>::value);
+#ifdef ZMQ_CPP17
+static_assert(std::is_invocable<decltype(&zmq::multipart_t::send),
+                                zmq::multipart_t *,
+                                zmq::socket_ref,
+                                int>::value,
+              "Can't multipart_t::send with socket_ref");
+static_assert(std::is_invocable<decltype(&zmq::multipart_t::recv),
+                                zmq::multipart_t *,
+                                zmq::socket_ref,
+                                int>::value,
+              "Can't multipart_t::recv with socket_ref");
+#endif
+static_assert(std::is_constructible<zmq::multipart_t, zmq::socket_ref>::value,
+              "Can't construct with socket_ref");
 
 /// \todo split this up into separate test cases
 ///

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -331,7 +331,7 @@ class multipart_t
     multipart_t() {}
 
     // Construct from socket receive
-    multipart_t(socket_t &socket) { recv(socket); }
+    multipart_t(socket_ref socket) { recv(socket); }
 
     // Construct from memory block
     multipart_t(const void *src, size_t size) { addmem(src, size); }
@@ -393,7 +393,7 @@ class multipart_t
     bool empty() const { return m_parts.empty(); }
 
     // Receive multipart message from socket
-    bool recv(socket_t &socket, int flags = 0)
+    bool recv(socket_ref socket, int flags = 0)
     {
         clear();
         bool more = true;
@@ -413,7 +413,7 @@ class multipart_t
     }
 
     // Send multipart message to socket
-    bool send(socket_t &socket, int flags = 0)
+    bool send(socket_ref socket, int flags = 0)
     {
         flags &= ~(ZMQ_SNDMORE);
         bool more = size() > 0;


### PR DESCRIPTION
This adds socket_ref support to `multipart_t`'s constructor and `send`/`recv` member functions, resolving issue #448 . All previously took a `socket_t&` instead. I don't *think* this will break anything, but if preferred I can add alias functions for `socket_t&` back in.