### PR TITLE
Add all draft socket types up to libzmq 4.3.4

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -2030,6 +2030,13 @@ enum class socket_type : int
     client = ZMQ_CLIENT,
     radio = ZMQ_RADIO,
     dish = ZMQ_DISH,
+    gather = ZMQ_GATHER,
+    scatter = ZMQ_SCATTER,
+    dgram = ZMQ_DGRAM,
+#endif
+#if defined(ZMQ_BUILD_DRAFT_API) && ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 3)
+    peer = ZMQ_PEER,
+    channel = ZMQ_CHANNEL,
 #endif
 #if ZMQ_VERSION_MAJOR >= 4
     stream = ZMQ_STREAM,


### PR DESCRIPTION
Resolving issue #462 and then some.

This adds the GATHER, SCATTER, CHANNEL, PEER and DGRAM socket types to `zmq::socket_type`. I can't find *any* documentation about DGRAM but since it was requested and does exist in zmq.h I figured I'd include it. I'm guessing that's when you map ZeroMQ messages to UDP datagrams?