### PR TITLE
context_t close no longer uses deprecated function

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -851,7 +851,7 @@ class context_t
 
         int rc;
         do {
-            rc = zmq_ctx_destroy(ptr);
+            rc = zmq_ctx_term(ptr);
         } while (rc == -1 && errno == EINTR);
 
         ZMQ_ASSERT(rc == 0);


### PR DESCRIPTION
linked issue #484

Relevant manual pages... 
http://api.zeromq.org/master:zmq-ctx-destroy
http://api.zeromq.org/master:zmq-ctx-term


zmq::context_t::close currently uses zmq_ctx_destroy when it should use zmq_ctx_term