### PR TITLE
Fixes https://github.com/zeromq/cppzmq/issues/361, by incorperating F…

### DIFF
--- a/libzmq-pkg-config/FindZeroMQ.cmake
+++ b/libzmq-pkg-config/FindZeroMQ.cmake
@@ -3,24 +3,32 @@ find_package(PkgConfig)
 pkg_check_modules(PC_LIBZMQ QUIET libzmq)
 
 set(ZeroMQ_VERSION ${PC_LIBZMQ_VERSION})
-find_library(ZeroMQ_LIBRARY NAMES libzmq.so libzmq.dylib libzmq.dll
-             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
-find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq-static.a libzmq.a libzmq.dll.a
-             PATHS ${PC_LIBZMQ_LIBDIR} ${PC_LIBZMQ_LIBRARY_DIRS})
 
-if(ZeroMQ_LIBRARY OR ZeroMQ_STATIC_LIBRARY)
+find_path(ZeroMQ_INCLUDE_DIR zmq.h
+        PATHS ${ZeroMQ_DIR}/include
+        ${PC_LIBZMQ_INCLUDE_DIRS})
+
+find_library(ZeroMQ_LIBRARY
+        NAMES zmq
+        PATHS ${ZeroMQ_DIR}/lib
+        ${PC_LIBZMQ_LIBDIR}
+        ${PC_LIBZMQ_LIBRARY_DIRS})
+
+if(ZeroMQ_LIBRARY)
     set(ZeroMQ_FOUND ON)
 endif()
 
-if (TARGET libzmq)
-    # avoid errors defining targets twice
-    return()
+set ( ZeroMQ_LIBRARIES ${ZeroMQ_LIBRARY} )
+set ( ZeroMQ_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIR} )
+
+if(NOT TARGET libzmq)
+    add_library(libzmq UNKNOWN IMPORTED)
+    set_target_properties(libzmq PROPERTIES
+            IMPORTED_LOCATION ${ZeroMQ_LIBRARIES}
+            INTERFACE_INCLUDE_DIRECTORIES ${ZeroMQ_INCLUDE_DIRS})
 endif()
 
-add_library(libzmq SHARED IMPORTED)
-set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
-set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION ${ZeroMQ_LIBRARY})
-
-add_library(libzmq-static STATIC IMPORTED ${PC_LIBZMQ_INCLUDE_DIRS})
-set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PC_LIBZMQ_INCLUDE_DIRS})
-set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION ${ZeroMQ_STATIC_LIBRARY})
+include ( FindPackageHandleStandardArgs )
+# handle the QUIETLY and REQUIRED arguments and set ZMQ_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args ( ZeroMQ DEFAULT_MSG ZeroMQ_LIBRARIES ZeroMQ_INCLUDE_DIRS )


### PR DESCRIPTION
Fixes https://github.com/zeromq/cppzmq/issues/361, by incorperating Ferdnyc's changes in OpenShot/libopenshot, previously cppzmq was not looking for the correct names, and rejected valid static library names when looking for zmq on windows, this fix aims to include those other names. 

I've only tested this under zmq from VCPKG with the static target triplet, it would be good for someone to test this against non static target to make sure this doesn't break anything that worked before (I can't test that on my end). 