### PR TITLE
ZMQ_DEPRECATED doesn't fallback for unrecognized compiler

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -67,6 +67,8 @@
 #define ZMQ_DEPRECATED(msg) __declspec(deprecated(msg))
 #elif defined(__GNUC__)
 #define ZMQ_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+#define ZMQ_DEPRECATED(msg)
 #endif
 
 #if defined(ZMQ_CPP17)


### PR DESCRIPTION
If you use a compiler outside of _MSC_VER and _GNUC__, then the if-else check doesn't provide a fallback for ZMQ_DEPRECATED macro which leads to a build failure.
Specifically in my case , I am using Oracle's SunPro 5.13.0.

My suggestions is to fallback to noop in case you don't recognize a compiler. Addressed #516