### PR TITLE
Format the code using existing .clang-format

### DIFF
--- a/examples/multipart_messages.cpp
+++ b/examples/multipart_messages.cpp
@@ -7,25 +7,19 @@ int main()
     zmq::socket_t sock1(ctx, zmq::socket_type::push);
     zmq::socket_t sock2(ctx, zmq::socket_type::pull);
     sock1.bind("tcp://127.0.0.1:*");
-    const std::string last_endpoint =
-        sock1.get(zmq::sockopt::last_endpoint);
-    std::cout << "Connecting to "
-              << last_endpoint << std::endl;
+    const std::string last_endpoint = sock1.get(zmq::sockopt::last_endpoint);
+    std::cout << "Connecting to " << last_endpoint << std::endl;
     sock2.connect(last_endpoint);
 
-    std::array<zmq::const_buffer, 2> send_msgs = {
-        zmq::str_buffer("foo"),
-        zmq::str_buffer("bar!")
-    };
+    std::array<zmq::const_buffer, 2> send_msgs = {zmq::str_buffer("foo"),
+                                                  zmq::str_buffer("bar!")};
     if (!zmq::send_multipart(sock1, send_msgs))
         return 1;
 
     std::vector<zmq::message_t> recv_msgs;
-    const auto ret = zmq::recv_multipart(
-        sock2, std::back_inserter(recv_msgs));
+    const auto ret = zmq::recv_multipart(sock2, std::back_inserter(recv_msgs));
     if (!ret)
         return 1;
-    std::cout << "Got " << *ret
-              << " messages" << std::endl;
+    std::cout << "Got " << *ret << " messages" << std::endl;
     return 0;
 }

--- a/examples/pubsub_multithread_inproc.cpp
+++ b/examples/pubsub_multithread_inproc.cpp
@@ -5,7 +5,8 @@
 #include "zmq.hpp"
 #include "zmq_addon.hpp"
 
-void PublisherThread(zmq::context_t *ctx) {
+void PublisherThread(zmq::context_t *ctx)
+{
     //  Prepare publisher
     zmq::socket_t publisher(*ctx, zmq::socket_type::pub);
     publisher.bind("inproc://#1");
@@ -25,7 +26,8 @@ void PublisherThread(zmq::context_t *ctx) {
     }
 }
 
-void SubscriberThread1(zmq::context_t *ctx) {
+void SubscriberThread1(zmq::context_t *ctx)
+{
     //  Prepare subscriber
     zmq::socket_t subscriber(*ctx, zmq::socket_type::sub);
     subscriber.connect("inproc://#1");
@@ -47,7 +49,8 @@ void SubscriberThread1(zmq::context_t *ctx) {
     }
 }
 
-void SubscriberThread2(zmq::context_t *ctx) {
+void SubscriberThread2(zmq::context_t *ctx)
+{
     //  Prepare our context and subscriber
     zmq::socket_t subscriber(*ctx, zmq::socket_type::sub);
     subscriber.connect("inproc://#1");
@@ -68,7 +71,8 @@ void SubscriberThread2(zmq::context_t *ctx) {
     }
 }
 
-int main() {
+int main()
+{
     /*
      * No I/O threads are involved in passing messages using the inproc transport.
      * Therefore, if you are using a ØMQ context for in-process messaging only you

--- a/tests/active_poller.cpp
+++ b/tests/active_poller.cpp
@@ -285,8 +285,7 @@ TEST_CASE("modify invalid socket throws", "[active_poller]")
     zmq::socket_t a{context, zmq::socket_type::push};
     zmq::socket_t b{std::move(a)};
     zmq::active_poller_t active_poller;
-    CHECK_THROWS_AS(active_poller.modify(a, zmq::event_flags::pollin),
-                    zmq::error_t);
+    CHECK_THROWS_AS(active_poller.modify(a, zmq::event_flags::pollin), zmq::error_t);
 }
 
 TEST_CASE("modify not added throws", "[active_poller]")
@@ -296,8 +295,7 @@ TEST_CASE("modify not added throws", "[active_poller]")
     zmq::socket_t b{context, zmq::socket_type::push};
     zmq::active_poller_t active_poller;
     CHECK_NOTHROW(active_poller.add(a, zmq::event_flags::pollin, no_op_handler));
-    CHECK_THROWS_AS(active_poller.modify(b, zmq::event_flags::pollin),
-                    zmq::error_t);
+    CHECK_THROWS_AS(active_poller.modify(b, zmq::event_flags::pollin), zmq::error_t);
 }
 
 TEST_CASE("modify simple", "[active_poller]")

--- a/tests/buffer.cpp
+++ b/tests/buffer.cpp
@@ -120,10 +120,10 @@ TEST_CASE("mutable_buffer creation C array", "[buffer]")
     BT d[10] = {};
     zmq::mutable_buffer b = zmq::buffer(d);
     CHECK(b.size() == 10 * sizeof(BT));
-    CHECK(b.data() == static_cast<BT*>(d));
+    CHECK(b.data() == static_cast<BT *>(d));
     zmq::const_buffer b2 = zmq::buffer(d, 4);
     CHECK(b2.size() == 4);
-    CHECK(b2.data() == static_cast<BT*>(d));
+    CHECK(b2.data() == static_cast<BT *>(d));
 }
 
 TEST_CASE("const_buffer creation C array", "[buffer]")
@@ -131,10 +131,10 @@ TEST_CASE("const_buffer creation C array", "[buffer]")
     const BT d[10] = {};
     zmq::const_buffer b = zmq::buffer(d);
     CHECK(b.size() == 10 * sizeof(BT));
-    CHECK(b.data() == static_cast<const BT*>(d));
+    CHECK(b.data() == static_cast<const BT *>(d));
     zmq::const_buffer b2 = zmq::buffer(d, 4);
     CHECK(b2.size() == 4);
-    CHECK(b2.data() == static_cast<const BT*>(d));
+    CHECK(b2.data() == static_cast<const BT *>(d));
 }
 
 TEST_CASE("mutable_buffer creation array", "[buffer]")
@@ -241,13 +241,13 @@ TEST_CASE("const_buffer creation with str_buffer", "[buffer]")
     const wchar_t wd[10] = {};
     zmq::const_buffer b = zmq::str_buffer(wd);
     CHECK(b.size() == 9 * sizeof(wchar_t));
-    CHECK(b.data() == static_cast<const wchar_t*>(wd));
+    CHECK(b.data() == static_cast<const wchar_t *>(wd));
 
     zmq::const_buffer b2_null = zmq::buffer("hello");
     constexpr zmq::const_buffer b2 = zmq::str_buffer("hello");
     CHECK(b2_null.size() == 6);
     CHECK(b2.size() == 5);
-    CHECK(std::string(static_cast<const char*>(b2.data()), b2.size()) == "hello");
+    CHECK(std::string(static_cast<const char *>(b2.data()), b2.size()) == "hello");
 }
 
 TEST_CASE("const_buffer creation with zbuf string literal char", "[buffer]")

--- a/tests/codec_multipart.cpp
+++ b/tests/codec_multipart.cpp
@@ -10,11 +10,10 @@ TEST_CASE("multipart codec empty", "[codec_multipart]")
     multipart_t mmsg;
     message_t msg = mmsg.encode();
     CHECK(msg.size() == 0);
-    
+
     multipart_t mmsg2;
     mmsg2.decode_append(msg);
     CHECK(mmsg2.size() == 0);
-
 }
 
 TEST_CASE("multipart codec small", "[codec_multipart]")
@@ -42,7 +41,7 @@ TEST_CASE("multipart codec big", "[codec_multipart]")
 {
     using namespace zmq;
 
-    message_t big(495);         // large size packing
+    message_t big(495); // large size packing
     big.data<char>()[0] = 'X';
 
     multipart_t mmsg;
@@ -66,10 +65,8 @@ TEST_CASE("multipart codec decode bad data overflow", "[codec_multipart]")
     message_t wrong_size(bad_data, 3);
     CHECK(wrong_size.size() == 3);
     CHECK(wrong_size.data<char>()[0] == 5);
-    
-    CHECK_THROWS_AS(
-        multipart_t::decode(wrong_size),
-        std::out_of_range);
+
+    CHECK_THROWS_AS(multipart_t::decode(wrong_size), std::out_of_range);
 }
 
 TEST_CASE("multipart codec decode bad data extra data", "[codec_multipart]")
@@ -80,10 +77,8 @@ TEST_CASE("multipart codec decode bad data extra data", "[codec_multipart]")
     message_t wrong_size(bad_data, 3);
     CHECK(wrong_size.size() == 3);
     CHECK(wrong_size.data<char>()[0] == 1);
-    
-    CHECK_THROWS_AS(
-        multipart_t::decode(wrong_size),
-        std::out_of_range);
+
+    CHECK_THROWS_AS(multipart_t::decode(wrong_size), std::out_of_range);
 }
 
 
@@ -110,14 +105,15 @@ TEST_CASE("multipart codec encode too big", "[codec_multipart]")
 }
 #endif
 
-TEST_CASE("multipart codec free function with vector of message_t", "[codec_multipart]")
+TEST_CASE("multipart codec free function with vector of message_t",
+          "[codec_multipart]")
 {
     using namespace zmq;
     std::vector<message_t> parts;
     parts.emplace_back("Hello", 5);
-    parts.emplace_back("World",5);
+    parts.emplace_back("World", 5);
     auto msg = encode(parts);
-    CHECK(msg.size() == 1 + 5 + 1 + 5 );
+    CHECK(msg.size() == 1 + 5 + 1 + 5);
     CHECK(msg.data<unsigned char>()[0] == 5);
     CHECK(msg.data<unsigned char>()[1] == 'H');
     CHECK(msg.data<unsigned char>()[6] == 5);
@@ -130,14 +126,15 @@ TEST_CASE("multipart codec free function with vector of message_t", "[codec_mult
     CHECK(parts[1].size() == 5);
 }
 
-TEST_CASE("multipart codec free function with vector of const_buffer", "[codec_multipart]")
+TEST_CASE("multipart codec free function with vector of const_buffer",
+          "[codec_multipart]")
 {
     using namespace zmq;
     std::vector<const_buffer> parts;
     parts.emplace_back("Hello", 5);
-    parts.emplace_back("World",5);
+    parts.emplace_back("World", 5);
     auto msg = encode(parts);
-    CHECK(msg.size() == 1 + 5 + 1 + 5 );
+    CHECK(msg.size() == 1 + 5 + 1 + 5);
     CHECK(msg.data<unsigned char>()[0] == 5);
     CHECK(msg.data<unsigned char>()[1] == 'H');
     CHECK(msg.data<unsigned char>()[6] == 5);
@@ -150,16 +147,17 @@ TEST_CASE("multipart codec free function with vector of const_buffer", "[codec_m
     CHECK(parts[1].size() == 5);
 }
 
-TEST_CASE("multipart codec free function with vector of mutable_buffer", "[codec_multipart]")
+TEST_CASE("multipart codec free function with vector of mutable_buffer",
+          "[codec_multipart]")
 {
     using namespace zmq;
     std::vector<mutable_buffer> parts;
     char hello[6] = "Hello";
     parts.emplace_back(hello, 5);
     char world[6] = "World";
-    parts.emplace_back(world,5);
+    parts.emplace_back(world, 5);
     auto msg = encode(parts);
-    CHECK(msg.size() == 1 + 5 + 1 + 5 );
+    CHECK(msg.size() == 1 + 5 + 1 + 5);
     CHECK(msg.data<unsigned char>()[0] == 5);
     CHECK(msg.data<unsigned char>()[1] == 'H');
     CHECK(msg.data<unsigned char>()[6] == 5);

--- a/tests/context.cpp
+++ b/tests/context.cpp
@@ -51,15 +51,13 @@ TEST_CASE("context - use socket after shutdown", "[context]")
     zmq::context_t context;
     zmq::socket_t sock(context, zmq::socket_type::rep);
     context.shutdown();
-    try
-    {
+    try {
         sock.connect("inproc://test");
         zmq::message_t msg;
-        (void)sock.recv(msg, zmq::recv_flags::dontwait);
+        (void) sock.recv(msg, zmq::recv_flags::dontwait);
         REQUIRE(false);
     }
-    catch (const zmq::error_t& e)
-    {
+    catch (const zmq::error_t &e) {
         REQUIRE(e.num() == ETERM);
     }
 }
@@ -73,12 +71,8 @@ TEST_CASE("context set/get options", "[context]")
     CHECK(context.get(zmq::ctxopt::io_threads) == 5);
 #endif
 
-    CHECK_THROWS_AS(
-        context.set(static_cast<zmq::ctxopt>(-42), 5),
-        zmq::error_t);
+    CHECK_THROWS_AS(context.set(static_cast<zmq::ctxopt>(-42), 5), zmq::error_t);
 
-    CHECK_THROWS_AS(
-        context.get(static_cast<zmq::ctxopt>(-42)),
-        zmq::error_t);
+    CHECK_THROWS_AS(context.get(static_cast<zmq::ctxopt>(-42)), zmq::error_t);
 }
 #endif

--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -4,9 +4,9 @@
 
 #if defined(ZMQ_CPP11)
 static_assert(!std::is_copy_constructible<zmq::message_t>::value,
-    "message_t should not be copy-constructible");
+              "message_t should not be copy-constructible");
 static_assert(!std::is_copy_assignable<zmq::message_t>::value,
-    "message_t should not be copy-assignable");
+              "message_t should not be copy-assignable");
 #endif
 #if (__cplusplus >= 201703L)
 static_assert(std::is_nothrow_swappable<zmq::message_t>::value,

--- a/tests/monitor.cpp
+++ b/tests/monitor.cpp
@@ -8,7 +8,7 @@
 
 class mock_monitor_t : public zmq::monitor_t
 {
-public:
+  public:
     void on_event_connect_delayed(const zmq_event_t &, const char *) ZMQ_OVERRIDE
     {
         ++connect_delayed;
@@ -38,11 +38,13 @@ TEST_CASE("monitor move construct", "[monitor]")
 {
     zmq::context_t ctx;
     zmq::socket_t sock(ctx, ZMQ_DEALER);
-    SECTION("move ctor empty") {
+    SECTION("move ctor empty")
+    {
         zmq::monitor_t monitor1;
         zmq::monitor_t monitor2 = std::move(monitor1);
     }
-    SECTION("move ctor init") {
+    SECTION("move ctor init")
+    {
         zmq::monitor_t monitor1;
         monitor1.init(sock, "inproc://monitor-client");
         zmq::monitor_t monitor2 = std::move(monitor1);
@@ -53,18 +55,21 @@ TEST_CASE("monitor move assign", "[monitor]")
 {
     zmq::context_t ctx;
     zmq::socket_t sock(ctx, ZMQ_DEALER);
-    SECTION("move assign empty") {
+    SECTION("move assign empty")
+    {
         zmq::monitor_t monitor1;
         zmq::monitor_t monitor2;
         monitor1 = std::move(monitor2);
     }
-    SECTION("move assign init") {
+    SECTION("move assign init")
+    {
         zmq::monitor_t monitor1;
         monitor1.init(sock, "inproc://monitor-client");
         zmq::monitor_t monitor2;
         monitor2 = std::move(monitor1);
     }
-    SECTION("move assign init both") {
+    SECTION("move assign init both")
+    {
         zmq::monitor_t monitor1;
         monitor1.init(sock, "inproc://monitor-client");
         zmq::monitor_t monitor2;
@@ -96,7 +101,7 @@ TEST_CASE("monitor init abort", "[monitor]")
 {
     class mock_monitor : public mock_monitor_t
     {
-    public:
+      public:
         mock_monitor(std::function<void(void)> handle_connected) :
             handle_connected{std::move(handle_connected)}
         {
@@ -117,16 +122,14 @@ TEST_CASE("monitor init abort", "[monitor]")
     std::condition_variable cond_var;
     bool done{false};
 
-    mock_monitor monitor([&]()
-    {
+    mock_monitor monitor([&]() {
         std::lock_guard<std::mutex> lock(mutex);
         done = true;
         cond_var.notify_one();
     });
     monitor.init(s.client, "inproc://foo");
 
-    auto thread = std::thread([&monitor]
-    {
+    auto thread = std::thread([&monitor] {
         while (monitor.check_event(-1)) {
         }
     });
@@ -135,7 +138,7 @@ TEST_CASE("monitor init abort", "[monitor]")
     {
         std::unique_lock<std::mutex> lock(mutex);
         CHECK(cond_var.wait_for(lock, std::chrono::seconds(1),
-            [&done] { return done; }));
+                                [&done] { return done; }));
     }
     CHECK(monitor.connect_delayed == 1);
     CHECK(monitor.connected == 1);

--- a/tests/multipart.cpp
+++ b/tests/multipart.cpp
@@ -84,8 +84,8 @@ TEST_CASE("multipart legacy test", "[multipart]")
     assert(copy != multipart);
     assert(multipart != copy);
 
-    multipart_t emptyMessage1 {};
-    multipart_t emptyMessage2 {};
+    multipart_t emptyMessage1{};
+    multipart_t emptyMessage2{};
 
     assert(emptyMessage1 == emptyMessage2);
     assert(emptyMessage2 == emptyMessage1);

--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -1,6 +1,7 @@
 #include "testutil.hpp"
 
-#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11) && !defined(ZMQ_CPP11_PARTIAL) && defined(ZMQ_HAVE_POLLER)
+#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)                              \
+  && !defined(ZMQ_CPP11_PARTIAL) && defined(ZMQ_HAVE_POLLER)
 
 #include <array>
 #include <memory>
@@ -9,25 +10,26 @@
 static_assert(std::is_nothrow_swappable_v<zmq::poller_t<>>);
 #endif
 static_assert(sizeof(zmq_poller_event_t) == sizeof(zmq::poller_event<>), "");
-static_assert(sizeof(zmq_poller_event_t) == sizeof(zmq::poller_event<zmq::
-                  no_user_data>), "");
+static_assert(sizeof(zmq_poller_event_t)
+                == sizeof(zmq::poller_event<zmq::no_user_data>),
+              "");
 static_assert(sizeof(zmq_poller_event_t) == sizeof(zmq::poller_event<int>), "");
 static_assert(alignof(zmq_poller_event_t) == alignof(zmq::poller_event<>), "");
 static_assert(alignof(zmq_poller_event_t) == alignof(zmq::poller_event<int>), "");
 
 static_assert(!std::is_copy_constructible<zmq::poller_t<>>::value,
-    "poller_t should not be copy-constructible");
+              "poller_t should not be copy-constructible");
 static_assert(!std::is_copy_assignable<zmq::poller_t<>>::value,
-    "poller_t should not be copy-assignable");
+              "poller_t should not be copy-assignable");
 
 TEST_CASE("event flags", "[poller]")
 {
     CHECK((zmq::event_flags::pollin | zmq::event_flags::pollout)
-        == static_cast<zmq::event_flags>(ZMQ_POLLIN | ZMQ_POLLOUT));
+          == static_cast<zmq::event_flags>(ZMQ_POLLIN | ZMQ_POLLOUT));
     CHECK((zmq::event_flags::pollin & zmq::event_flags::pollout)
-        == static_cast<zmq::event_flags>(ZMQ_POLLIN & ZMQ_POLLOUT));
+          == static_cast<zmq::event_flags>(ZMQ_POLLIN & ZMQ_POLLOUT));
     CHECK((zmq::event_flags::pollin ^ zmq::event_flags::pollout)
-        == static_cast<zmq::event_flags>(ZMQ_POLLIN ^ ZMQ_POLLOUT));
+          == static_cast<zmq::event_flags>(ZMQ_POLLIN ^ ZMQ_POLLOUT));
     CHECK(~zmq::event_flags::pollin == static_cast<zmq::event_flags>(~ZMQ_POLLIN));
 }
 
@@ -108,8 +110,8 @@ TEST_CASE("poller add handler invalid events type", "[poller]")
     zmq::poller_t<> poller;
     short invalid_events_type = 2 << 10;
     CHECK_THROWS_AS(
-        poller.add(socket, static_cast<zmq::event_flags>(invalid_events_type)),
-        zmq::error_t);
+      poller.add(socket, static_cast<zmq::event_flags>(invalid_events_type)),
+      zmq::error_t);
 }
 #endif
 
@@ -120,8 +122,7 @@ TEST_CASE("poller add handler twice throws", "[poller]")
     zmq::poller_t<> poller;
     poller.add(socket, zmq::event_flags::pollin);
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(poller.add(socket, zmq::event_flags::pollin),
-                    zmq::error_t);
+    CHECK_THROWS_AS(poller.add(socket, zmq::event_flags::pollin), zmq::error_t);
 }
 
 TEST_CASE("poller wait with no handlers throws", "[poller]")
@@ -218,8 +219,7 @@ TEST_CASE("poller modify empty throws", "[poller]")
     zmq::context_t context;
     zmq::socket_t socket{context, zmq::socket_type::push};
     zmq::poller_t<> poller;
-    CHECK_THROWS_AS(poller.modify(socket, zmq::event_flags::pollin),
-                    zmq::error_t);
+    CHECK_THROWS_AS(poller.modify(socket, zmq::event_flags::pollin), zmq::error_t);
 }
 
 TEST_CASE("poller modify invalid socket throws", "[poller]")
@@ -248,7 +248,7 @@ TEST_CASE("poller modify simple", "[poller]")
     zmq::poller_t<> poller;
     CHECK_NOTHROW(poller.add(a, zmq::event_flags::pollin));
     CHECK_NOTHROW(
-        poller.modify(a, zmq::event_flags::pollin | zmq::event_flags::pollout));
+      poller.modify(a, zmq::event_flags::pollin | zmq::event_flags::pollout));
 }
 
 TEST_CASE("poller poll client server", "[poller]")
@@ -270,11 +270,10 @@ TEST_CASE("poller poll client server", "[poller]")
 
     // Modify server socket with pollout flag
     CHECK_NOTHROW(
-        poller.modify(s.server, zmq::event_flags::pollin | zmq::event_flags::pollout
-        ));
+      poller.modify(s.server, zmq::event_flags::pollin | zmq::event_flags::pollout));
     CHECK(1 == poller.wait_all(events, std::chrono::milliseconds{500}));
-    CHECK((zmq::event_flags::pollin | zmq::event_flags::pollout) == events[0].events)
-    ;
+    CHECK((zmq::event_flags::pollin | zmq::event_flags::pollout)
+          == events[0].events);
 }
 
 TEST_CASE("poller wait one return", "[poller]")
@@ -303,8 +302,7 @@ TEST_CASE("poller wait on move constructed", "[poller]")
     zmq::poller_t<> b{std::move(a)};
     std::vector<zmq::poller_event<>> events(1);
     /// \todo the actual error code should be checked
-    CHECK_THROWS_AS(a.wait_all(events, std::chrono::milliseconds{10}),
-                    zmq::error_t);
+    CHECK_THROWS_AS(a.wait_all(events, std::chrono::milliseconds{10}), zmq::error_t);
     CHECK(1 == b.wait_all(events, std::chrono::milliseconds{-1}));
 }
 
@@ -318,8 +316,7 @@ TEST_CASE("poller wait on move assigned", "[poller]")
     b = {std::move(a)};
     /// \todo the TEST_CASE error code should be checked
     std::vector<zmq::poller_event<>> events(1);
-    CHECK_THROWS_AS(a.wait_all(events, std::chrono::milliseconds{10}),
-                    zmq::error_t);
+    CHECK_THROWS_AS(a.wait_all(events, std::chrono::milliseconds{10}), zmq::error_t);
     CHECK(1 == b.wait_all(events, std::chrono::milliseconds{-1}));
 }
 

--- a/tests/recv_multipart.cpp
+++ b/tests/recv_multipart.cpp
@@ -10,7 +10,8 @@ TEST_CASE("recv_multipart test", "[recv_multipart]")
     output.bind("inproc://multipart.test");
     input.connect("inproc://multipart.test");
 
-    SECTION("send 1 message") {
+    SECTION("send 1 message")
+    {
         input.send(zmq::str_buffer("hello"));
 
         std::vector<zmq::message_t> msgs;
@@ -20,7 +21,8 @@ TEST_CASE("recv_multipart test", "[recv_multipart]")
         REQUIRE(msgs.size() == 1);
         CHECK(msgs[0].size() == 5);
     }
-    SECTION("send 2 messages") {
+    SECTION("send 2 messages")
+    {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
         input.send(zmq::str_buffer("world!"));
 
@@ -32,14 +34,16 @@ TEST_CASE("recv_multipart test", "[recv_multipart]")
         CHECK(msgs[0].size() == 5);
         CHECK(msgs[1].size() == 6);
     }
-    SECTION("send no messages, dontwait") {
+    SECTION("send no messages, dontwait")
+    {
         std::vector<zmq::message_t> msgs;
         auto ret = zmq::recv_multipart(output, std::back_inserter(msgs),
                                        zmq::recv_flags::dontwait);
         CHECK_FALSE(ret);
         REQUIRE(msgs.size() == 0);
     }
-    SECTION("send 1 partial message, dontwait") {
+    SECTION("send 1 partial message, dontwait")
+    {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
 
         std::vector<zmq::message_t> msgs;
@@ -48,11 +52,12 @@ TEST_CASE("recv_multipart test", "[recv_multipart]")
         CHECK_FALSE(ret);
         REQUIRE(msgs.size() == 0);
     }
-    SECTION("recv with invalid socket") {
+    SECTION("recv with invalid socket")
+    {
         std::vector<zmq::message_t> msgs;
         CHECK_THROWS_AS(
-            zmq::recv_multipart(zmq::socket_ref(), std::back_inserter(msgs)),
-            zmq::error_t);
+          zmq::recv_multipart(zmq::socket_ref(), std::back_inserter(msgs)),
+          zmq::error_t);
     }
 }
 
@@ -64,7 +69,8 @@ TEST_CASE("recv_multipart_n test", "[recv_multipart]")
     output.bind("inproc://multipart.test");
     input.connect("inproc://multipart.test");
 
-    SECTION("send 1 message") {
+    SECTION("send 1 message")
+    {
         input.send(zmq::str_buffer("hello"));
 
         std::array<zmq::message_t, 1> msgs;
@@ -73,7 +79,8 @@ TEST_CASE("recv_multipart_n test", "[recv_multipart]")
         CHECK(*ret == 1);
         CHECK(msgs[0].size() == 5);
     }
-    SECTION("send 1 message 2") {
+    SECTION("send 1 message 2")
+    {
         input.send(zmq::str_buffer("hello"));
 
         std::array<zmq::message_t, 2> msgs;
@@ -83,25 +90,26 @@ TEST_CASE("recv_multipart_n test", "[recv_multipart]")
         CHECK(msgs[0].size() == 5);
         CHECK(msgs[1].size() == 0);
     }
-    SECTION("send 2 messages, recv 1") {
+    SECTION("send 2 messages, recv 1")
+    {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
         input.send(zmq::str_buffer("world!"));
 
         std::array<zmq::message_t, 1> msgs;
-        CHECK_THROWS_AS(
-            zmq::recv_multipart_n(output, msgs.data(), msgs.size()),
-            std::runtime_error);
+        CHECK_THROWS_AS(zmq::recv_multipart_n(output, msgs.data(), msgs.size()),
+                        std::runtime_error);
     }
-    SECTION("recv 0") {
+    SECTION("recv 0")
+    {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
         input.send(zmq::str_buffer("world!"));
 
         std::array<zmq::message_t, 1> msgs;
-        CHECK_THROWS_AS(
-            zmq::recv_multipart_n(output, msgs.data(), 0),
-            std::runtime_error);
+        CHECK_THROWS_AS(zmq::recv_multipart_n(output, msgs.data(), 0),
+                        std::runtime_error);
     }
-    SECTION("send 2 messages") {
+    SECTION("send 2 messages")
+    {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
         input.send(zmq::str_buffer("world!"));
 
@@ -112,14 +120,16 @@ TEST_CASE("recv_multipart_n test", "[recv_multipart]")
         CHECK(msgs[0].size() == 5);
         CHECK(msgs[1].size() == 6);
     }
-    SECTION("send no messages, dontwait") {
+    SECTION("send no messages, dontwait")
+    {
         std::array<zmq::message_t, 1> msgs;
         auto ret = zmq::recv_multipart_n(output, msgs.data(), msgs.size(),
                                          zmq::recv_flags::dontwait);
         CHECK_FALSE(ret);
         REQUIRE(msgs[0].size() == 0);
     }
-    SECTION("send 1 partial message, dontwait") {
+    SECTION("send 1 partial message, dontwait")
+    {
         input.send(zmq::str_buffer("hello"), zmq::send_flags::sndmore);
 
         std::array<zmq::message_t, 1> msgs;
@@ -128,11 +138,12 @@ TEST_CASE("recv_multipart_n test", "[recv_multipart]")
         CHECK_FALSE(ret);
         REQUIRE(msgs[0].size() == 0);
     }
-    SECTION("recv with invalid socket") {
+    SECTION("recv with invalid socket")
+    {
         std::array<zmq::message_t, 1> msgs;
         CHECK_THROWS_AS(
-            zmq::recv_multipart_n(zmq::socket_ref(), msgs.data(), msgs.size()),
-            zmq::error_t);
+          zmq::recv_multipart_n(zmq::socket_ref(), msgs.data(), msgs.size()),
+          zmq::error_t);
     }
 }
 

--- a/tests/send_multipart.cpp
+++ b/tests/send_multipart.cpp
@@ -12,13 +12,15 @@ TEST_CASE("send_multipart test", "[send_multipart]")
     output.bind("inproc://multipart.test");
     input.connect("inproc://multipart.test");
 
-    SECTION("send 0 messages") {
+    SECTION("send 0 messages")
+    {
         std::vector<zmq::message_t> imsgs;
         auto iret = zmq::send_multipart(input, imsgs);
         REQUIRE(iret);
         CHECK(*iret == 0);
     }
-    SECTION("send 1 message") {
+    SECTION("send 1 message")
+    {
         std::array<zmq::message_t, 1> imsgs = {zmq::message_t(3)};
         auto iret = zmq::send_multipart(input, imsgs);
         REQUIRE(iret);
@@ -31,7 +33,8 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         REQUIRE(omsgs.size() == 1);
         CHECK(omsgs[0].size() == 3);
     }
-    SECTION("send 2 messages") {
+    SECTION("send 2 messages")
+    {
         std::array<zmq::message_t, 2> imsgs = {zmq::message_t(3), zmq::message_t(4)};
         auto iret = zmq::send_multipart(input, imsgs);
         REQUIRE(iret);
@@ -45,7 +48,8 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         CHECK(omsgs[0].size() == 3);
         CHECK(omsgs[1].size() == 4);
     }
-    SECTION("send 2 messages, const_buffer") {
+    SECTION("send 2 messages, const_buffer")
+    {
         std::array<zmq::const_buffer, 2> imsgs = {zmq::str_buffer("foo"),
                                                   zmq::str_buffer("bar!")};
         auto iret = zmq::send_multipart(input, imsgs);
@@ -60,10 +64,11 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         CHECK(omsgs[0].size() == 3);
         CHECK(omsgs[1].size() == 4);
     }
-    SECTION("send 2 messages, mutable_buffer") {
+    SECTION("send 2 messages, mutable_buffer")
+    {
         char buf[4] = {};
-        std::array<zmq::mutable_buffer, 2> imsgs = {
-            zmq::buffer(buf, 3), zmq::buffer(buf)};
+        std::array<zmq::mutable_buffer, 2> imsgs = {zmq::buffer(buf, 3),
+                                                    zmq::buffer(buf)};
         auto iret = zmq::send_multipart(input, imsgs);
         REQUIRE(iret);
         CHECK(*iret == 2);
@@ -76,7 +81,8 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         CHECK(omsgs[0].size() == 3);
         CHECK(omsgs[1].size() == 4);
     }
-    SECTION("send 2 messages, dontwait") {
+    SECTION("send 2 messages, dontwait")
+    {
         zmq::socket_t push(context, ZMQ_PUSH);
         push.bind("inproc://multipart.test.push");
 
@@ -84,7 +90,8 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         auto iret = zmq::send_multipart(push, imsgs, zmq::send_flags::dontwait);
         REQUIRE_FALSE(iret);
     }
-    SECTION("send, misc. containers") {
+    SECTION("send, misc. containers")
+    {
         std::vector<zmq::message_t> msgs_vec;
         msgs_vec.emplace_back(3);
         msgs_vec.emplace_back(4);
@@ -105,17 +112,16 @@ TEST_CASE("send_multipart test", "[send_multipart]")
         REQUIRE(iret);
         CHECK(*iret == 2);
         // rvalue
-        iret = zmq::send_multipart(input,
-                                   std::initializer_list<zmq::const_buffer>{
-                                       zmq::str_buffer("foo"),
-                                       zmq::str_buffer("bar!")});
+        iret = zmq::send_multipart(
+          input, std::initializer_list<zmq::const_buffer>{zmq::str_buffer("foo"),
+                                                          zmq::str_buffer("bar!")});
         REQUIRE(iret);
         CHECK(*iret == 2);
     }
-    SECTION("send with invalid socket") {
+    SECTION("send with invalid socket")
+    {
         std::vector<zmq::message_t> msgs(1);
-        CHECK_THROWS_AS(zmq::send_multipart(zmq::socket_ref(), msgs),
-                        zmq::error_t);
+        CHECK_THROWS_AS(zmq::send_multipart(zmq::socket_ref(), msgs), zmq::error_t);
     }
 }
 #endif

--- a/tests/socket.cpp
+++ b/tests/socket.cpp
@@ -407,7 +407,8 @@ TEST_CASE("socket check integral options", "[socket]")
 #ifdef ZMQ_TYPE
     check_integral_opt_get<int>(zmq::sockopt::type, router, "type");
 #ifdef ZMQ_CPP11
-    check_integral_opt_get<zmq::socket_type>(zmq::sockopt::socket_type, router, "socket_type");
+    check_integral_opt_get<zmq::socket_type>(zmq::sockopt::socket_type, router,
+                                             "socket_type");
 #endif // ZMQ_CPP11
 #endif // ZMQ_TYPE
 

--- a/tests/socket_ref.cpp
+++ b/tests/socket_ref.cpp
@@ -8,7 +8,7 @@ static_assert(std::is_nothrow_swappable_v<zmq::socket_ref>);
 static_assert(sizeof(zmq::socket_ref) == sizeof(void *), "size mismatch");
 static_assert(alignof(zmq::socket_ref) == alignof(void *), "alignment mismatch");
 static_assert(ZMQ_IS_TRIVIALLY_COPYABLE(zmq::socket_ref),
-    "needs to be trivially copyable");
+              "needs to be trivially copyable");
 
 TEST_CASE("socket_ref default init", "[socket_ref]")
 {

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -250,8 +250,8 @@ template<class Iter>
 using iter_value_t = typename std::iterator_traits<Iter>::value_type;
 
 template<class Range>
-using range_iter_t = decltype(
-  ranges::begin(std::declval<typename std::remove_reference<Range>::type &>()));
+using range_iter_t = decltype(ranges::begin(
+  std::declval<typename std::remove_reference<Range>::type &>()));
 
 template<class Range> using range_value_t = iter_value_t<range_iter_t<Range>>;
 
@@ -262,9 +262,10 @@ template<class T, class = void> struct is_range : std::false_type
 template<class T>
 struct is_range<
   T,
-  void_t<decltype(
-    ranges::begin(std::declval<typename std::remove_reference<T>::type &>())
-    == ranges::end(std::declval<typename std::remove_reference<T>::type &>()))>>
+  void_t<decltype(ranges::begin(
+                    std::declval<typename std::remove_reference<T>::type &>())
+                  == ranges::end(
+                    std::declval<typename std::remove_reference<T>::type &>()))>>
     : std::true_type
 {
 };
@@ -301,7 +302,8 @@ class error_t : public std::exception
     int errnum;
 };
 
-namespace detail {
+namespace detail
+{
 inline int poll(zmq_pollitem_t *items_, size_t nitems_, long timeout_)
 {
     int rc = zmq_poll(items_, static_cast<int>(nitems_), timeout_);
@@ -333,7 +335,7 @@ inline int
 poll(zmq_pollitem_t const *items, size_t nitems, std::chrono::milliseconds timeout)
 {
     return detail::poll(const_cast<zmq_pollitem_t *>(items), nitems,
-                static_cast<long>(timeout.count()));
+                        static_cast<long>(timeout.count()));
 }
 
 ZMQ_DEPRECATED("from 4.3.1, use poll taking non-const items")
@@ -341,17 +343,19 @@ inline int poll(std::vector<zmq_pollitem_t> const &items,
                 std::chrono::milliseconds timeout)
 {
     return detail::poll(const_cast<zmq_pollitem_t *>(items.data()), items.size(),
-                static_cast<long>(timeout.count()));
+                        static_cast<long>(timeout.count()));
 }
 
 ZMQ_DEPRECATED("from 4.3.1, use poll taking non-const items")
 inline int poll(std::vector<zmq_pollitem_t> const &items, long timeout_ = -1)
 {
-    return detail::poll(const_cast<zmq_pollitem_t *>(items.data()), items.size(), timeout_);
+    return detail::poll(const_cast<zmq_pollitem_t *>(items.data()), items.size(),
+                        timeout_);
 }
 
-inline int
-poll(zmq_pollitem_t *items, size_t nitems, std::chrono::milliseconds timeout = std::chrono::milliseconds{-1})
+inline int poll(zmq_pollitem_t *items,
+                size_t nitems,
+                std::chrono::milliseconds timeout = std::chrono::milliseconds{-1})
 {
     return detail::poll(items, nitems, static_cast<long>(timeout.count()));
 }
@@ -359,7 +363,8 @@ poll(zmq_pollitem_t *items, size_t nitems, std::chrono::milliseconds timeout = s
 inline int poll(std::vector<zmq_pollitem_t> &items,
                 std::chrono::milliseconds timeout = std::chrono::milliseconds{-1})
 {
-    return detail::poll(items.data(), items.size(), static_cast<long>(timeout.count()));
+    return detail::poll(items.data(), items.size(),
+                        static_cast<long>(timeout.count()));
 }
 
 ZMQ_DEPRECATED("from 4.3.1, use poll taking std::chrono::duration instead of long")
@@ -372,7 +377,8 @@ template<std::size_t SIZE>
 inline int poll(std::array<zmq_pollitem_t, SIZE> &items,
                 std::chrono::milliseconds timeout = std::chrono::milliseconds{-1})
 {
-    return detail::poll(items.data(), items.size(), static_cast<long>(timeout.count()));
+    return detail::poll(items.data(), items.size(),
+                        static_cast<long>(timeout.count()));
 }
 #endif
 
@@ -1091,7 +1097,7 @@ class mutable_buffer
     mutable_buffer &operator+=(size_t n) noexcept
     {
         // (std::min) is a workaround for when a min macro is defined
-        const auto shift = (std::min)(n, _size);
+        const auto shift = (std::min) (n, _size);
         _data = static_cast<char *>(_data) + shift;
         _size -= shift;
         return *this;
@@ -1104,8 +1110,8 @@ class mutable_buffer
 
 inline mutable_buffer operator+(const mutable_buffer &mb, size_t n) noexcept
 {
-    return mutable_buffer(static_cast<char *>(mb.data()) + (std::min)(n, mb.size()),
-                          mb.size() - (std::min)(n, mb.size()));
+    return mutable_buffer(static_cast<char *>(mb.data()) + (std::min) (n, mb.size()),
+                          mb.size() - (std::min) (n, mb.size()));
 }
 inline mutable_buffer operator+(size_t n, const mutable_buffer &mb) noexcept
 {
@@ -1131,7 +1137,7 @@ class const_buffer
     constexpr size_t size() const noexcept { return _size; }
     const_buffer &operator+=(size_t n) noexcept
     {
-        const auto shift = (std::min)(n, _size);
+        const auto shift = (std::min) (n, _size);
         _data = static_cast<const char *>(_data) + shift;
         _size -= shift;
         return *this;
@@ -1145,8 +1151,8 @@ class const_buffer
 inline const_buffer operator+(const const_buffer &cb, size_t n) noexcept
 {
     return const_buffer(static_cast<const char *>(cb.data())
-                          + (std::min)(n, cb.size()),
-                        cb.size() - (std::min)(n, cb.size()));
+                          + (std::min) (n, cb.size()),
+                        cb.size() - (std::min) (n, cb.size()));
 }
 inline const_buffer operator+(size_t n, const const_buffer &cb) noexcept
 {
@@ -1169,7 +1175,7 @@ constexpr mutable_buffer buffer(const mutable_buffer &mb) noexcept
 }
 inline mutable_buffer buffer(const mutable_buffer &mb, size_t n) noexcept
 {
-    return mutable_buffer(mb.data(), (std::min)(mb.size(), n));
+    return mutable_buffer(mb.data(), (std::min) (mb.size(), n));
 }
 constexpr const_buffer buffer(const const_buffer &cb) noexcept
 {
@@ -1177,7 +1183,7 @@ constexpr const_buffer buffer(const const_buffer &cb) noexcept
 }
 inline const_buffer buffer(const const_buffer &cb, size_t n) noexcept
 {
-    return const_buffer(cb.data(), (std::min)(cb.size(), n));
+    return const_buffer(cb.data(), (std::min) (cb.size(), n));
 }
 
 namespace detail
@@ -1230,7 +1236,7 @@ auto buffer_contiguous_sequence(Seq &&seq, size_t n_bytes) noexcept
 
     const auto size = seq_size(seq);
     return buffer(size != 0u ? std::addressof(*std::begin(seq)) : nullptr,
-                  (std::min)(size * sizeof(T), n_bytes));
+                  (std::min) (size * sizeof(T), n_bytes));
 }
 
 } // namespace detail
@@ -1995,7 +2001,7 @@ class socket_base
           zmq_recv(_handle, buf.data(), buf.size(), static_cast<int>(flags));
         if (nbytes >= 0) {
             return recv_buffer_size{
-              (std::min)(static_cast<size_t>(nbytes), buf.size()),
+              (std::min) (static_cast<size_t>(nbytes), buf.size()),
               static_cast<size_t>(nbytes)};
         }
         if (zmq_errno() == EAGAIN)
@@ -2107,27 +2113,33 @@ inline bool operator!=(std::nullptr_t /*p*/, socket_ref sr) ZMQ_NOTHROW
 }
 #endif
 
-inline bool operator==(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
+inline bool operator==(const detail::socket_base &a,
+                       const detail::socket_base &b) ZMQ_NOTHROW
 {
     return std::equal_to<const void *>()(a.handle(), b.handle());
 }
-inline bool operator!=(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
+inline bool operator!=(const detail::socket_base &a,
+                       const detail::socket_base &b) ZMQ_NOTHROW
 {
     return !(a == b);
 }
-inline bool operator<(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
+inline bool operator<(const detail::socket_base &a,
+                      const detail::socket_base &b) ZMQ_NOTHROW
 {
     return std::less<const void *>()(a.handle(), b.handle());
 }
-inline bool operator>(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
+inline bool operator>(const detail::socket_base &a,
+                      const detail::socket_base &b) ZMQ_NOTHROW
 {
     return b < a;
 }
-inline bool operator<=(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
+inline bool operator<=(const detail::socket_base &a,
+                       const detail::socket_base &b) ZMQ_NOTHROW
 {
     return !(a > b);
 }
-inline bool operator>=(const detail::socket_base& a, const detail::socket_base& b) ZMQ_NOTHROW
+inline bool operator>=(const detail::socket_base &a,
+                       const detail::socket_base &b) ZMQ_NOTHROW
 {
     return !(a < b);
 }
@@ -2339,11 +2351,11 @@ class monitor_t
           {_monitor_socket.handle(), 0, ZMQ_POLLIN, 0},
         };
 
-        #ifdef ZMQ_CPP11
+#ifdef ZMQ_CPP11
         zmq::poll(&items[0], 1, std::chrono::milliseconds(timeout));
-        #else
+#else
         zmq::poll(&items[0], 1, timeout);
-        #endif
+#endif
 
         if (items[0].revents & ZMQ_POLLIN) {
             int rc = zmq_msg_recv(eventMsg.handle(), _monitor_socket.handle(), 0);
@@ -2418,7 +2430,8 @@ class monitor_t
             case ZMQ_EVENT_DISCONNECTED:
                 on_event_disconnected(*event, address.c_str());
                 break;
-#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 0) || (defined(ZMQ_BUILD_DRAFT_API) && ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 3))
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 0)                                        \
+  || (defined(ZMQ_BUILD_DRAFT_API) && ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 2, 3))
             case ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL:
                 on_event_handshake_failed_no_detail(*event, address.c_str());
                 break;


### PR DESCRIPTION
The repo has a .clang-format defined, but since there is nothing enforcing it, it is possible to commit code not properly formatted.

Executed the following command from Command Prompt in the root of the repository, without any other changes:
`for /r %a in (*.cpp *.h *.hpp) do "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\bin\clang-format.exe" -i "%a"`
