### PR TITLE
Added #include <thread> for build fix on fedora

### DIFF
--- a/examples/pubsub_multithread_inproc.cpp
+++ b/examples/pubsub_multithread_inproc.cpp
@@ -1,6 +1,7 @@
 #include <future>
 #include <iostream>
 #include <string>
+#include <thread>
 
 #include "zmq.hpp"
 #include "zmq_addon.hpp"


### PR DESCRIPTION
Compilation fails on Fedora 35 without thread header.