### PR TITLE
Suppress ZMQ_EXTENDED_CONSTEXPR on gcc with partial C++14 support

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -94,7 +94,7 @@
 #define ZMQ_CONSTEXPR_VAR const
 #define ZMQ_CPP11_DEPRECATED(msg)
 #endif
-#if defined(ZMQ_CPP14) && (!defined(_MSC_VER) || _MSC_VER > 1900)
+#if defined(ZMQ_CPP14) && (!defined(_MSC_VER) || _MSC_VER > 1900) && (!defined(__GNUC__) || __GNUC__ > 5 || (__GNUC__ == 5 && __GNUC_MINOR__ > 3))
 #define ZMQ_EXTENDED_CONSTEXPR
 #endif
 #if defined(ZMQ_CPP17)


### PR DESCRIPTION
cf. https://gcc.gnu.org/projects/cxx-status.html#cxx14