### PR TITLE
Updating Catch2 v2 to v2.13.9

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ if (NOT Catch2_FOUND)
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v2.13.4)
+    GIT_TAG        v2.13.9)
 
   FetchContent_MakeAvailable(Catch2)
 


### PR DESCRIPTION
Fixes issue with MINSIGSTKSZ which is no longer a constant -> https://github.com/JuliaLang/julia/issues/39822

Issue was fixed in https://github.com/catchorg/Catch2/releases/tag/v2.13.5

Does not build in Ubuntu 22.04 with GCC 11.2.0 without this update.