### PR TITLE
Remove ENABLE_DRAFTS option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
       run: |
         cmake -H. -Bbuild ${{ matrix.platform}} ${{ matrix.coverage }} \
           -DCMAKE_BUILD_TYPE=${BUILDTYPE} \
-          -DENABLE_DRAFTS=${{ matrix.drafts }} \
           -DCMAKE_CXX_STANDARD=${{ matrix.cppstd }}
         cmake --build build --config ${BUILDTYPE} -j ${THREADS}
         echo "CPPZMQ=${PWD}/build" >> ${GITHUB_ENV}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         cc: ["gcc-10"]
         cxx: ["g++-10"]
         drafts: ["ON"]
-        libzmq: ["4.3.4"]
+        libzmq: ["4.3.5"]
         libzmqbuild: ["cmake"]
         include:
           # older libzmq and without draft
@@ -33,7 +33,7 @@ jobs:
             cc: "gcc-11"
             cxx: "g++-11"
             drafts: "OFF"
-            libzmq: "4.3.4"
+            libzmq: "4.3.5"
             libzmqbuild: "cmake"
           # coverage (gcc version should match gcov version)
           - os: "ubuntu-20.04"
@@ -41,7 +41,7 @@ jobs:
             cc: "gcc-9"
             cxx: "g++-9"
             drafts: "ON"
-            libzmq: "4.3.4"
+            libzmq: "4.3.5"
             libzmqbuild: "cmake"
             coverage: "-DCOVERAGE=ON"
             aptinstall: "lcov"
@@ -51,7 +51,7 @@ jobs:
             cc: "clang-12"
             cxx: "clang++-12"
             drafts: "ON"
-            libzmq: "4.3.4"
+            libzmq: "4.3.5"
             libzmqbuild: "cmake"
           # macos
           - os: "macos-latest"
@@ -59,7 +59,7 @@ jobs:
             cc: "clang"
             cxx: "clang++"
             drafts: "OFF"
-            libzmq: "4.3.4"
+            libzmq: "4.3.5"
             libzmqbuild: false
             brewinstall: "zeromq"
           # windows
@@ -68,7 +68,7 @@ jobs:
             cc: "msbuild"
             cxx: "msbuild"
             drafts: "ON"
-            libzmq: "4.3.4"
+            libzmq: "4.3.5"
             libzmqbuild: "cmake"
             platform: "-Ax64"
           - os: "windows-2022"
@@ -76,7 +76,7 @@ jobs:
             cc: "msbuild"
             cxx: "msbuild"
             drafts: "ON"
-            libzmq: "4.3.4"
+            libzmq: "4.3.5"
             libzmqbuild: "cmake"
             platform: "-Ax64"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,18 +26,6 @@ if (NOT TARGET libzmq AND NOT TARGET libzmq-static)
   endif()
 endif()
 
-if (EXISTS "${CMAKE_SOURCE_DIR}/.git")
-    OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" ON)
-else ()
-    OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" OFF)
-endif ()
-if (ENABLE_DRAFTS)
-    ADD_DEFINITIONS (-DZMQ_BUILD_DRAFT_API)
-    set (pkg_config_defines "-DZMQ_BUILD_DRAFT_API=1")
-else (ENABLE_DRAFTS)
-    set (pkg_config_defines "")
-endif (ENABLE_DRAFTS)
-
 message(STATUS "cppzmq v${cppzmq_VERSION}")
 
 set(CPPZMQ_HEADERS


### PR DESCRIPTION
This option added ZMQ_BUILD_DRAFT_API to the compile definitions. However, this should be propagated by libzmq (see https://github.com/zeromq/libzmq/pull/4323 and https://github.com/zeromq/cppzmq/issues/477).

Closes https://github.com/zeromq/cppzmq/issues/477.