### PR TITLE
add a parameter for multipart_t::send

### DIFF
--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -413,7 +413,7 @@ class multipart_t
     }
 
     // Send multipart message to socket
-    bool send(socket_ref socket, int flags = 0)
+    bool send(socket_ref socket, int flags = 0, bool need_clear = true)
     {
         flags &= ~(ZMQ_SNDMORE);
         bool more = size() > 0;
@@ -429,7 +429,9 @@ class multipart_t
                 return false;
 #endif
         }
-        clear();
+        if(need_clear){
+            clear();
+        }
         return true;
     }
 


### PR DESCRIPTION
I need send message and recv message to do ACK, when I not recv the ack message I need to send it again.  I don't want to use clone, because need time to copy.

 