### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Build steps:
    - cd vcpkg
    - ./bootstrap-vcpkg.sh # bootstrap-vcpkg.bat for Powershell
    - ./vcpkg integrate install
-   - ./vcpkg install cmark
+   - ./vcpkg install cppzmq
 
 Using this:
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ Build steps:
    - cmake ..
    - sudo make -j4 install
 
+3. Build cppzmq via [vcpkg](https://github.com/Microsoft/vcpkg/). This does an out of source build and installs the build files
+   - git clone https://github.com/Microsoft/vcpkg.git
+   - cd vcpkg
+   - ./bootstrap-vcpkg.sh
+   - ./vcpkg integrate install
+   - ./vcpkg install cmark
+
 Using this:
 
 A cmake find package scripts is provided for you to easily include this library.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Build steps:
 3. Build cppzmq via [vcpkg](https://github.com/Microsoft/vcpkg/). This does an out of source build and installs the build files
    - git clone https://github.com/Microsoft/vcpkg.git
    - cd vcpkg
-   - ./bootstrap-vcpkg.sh
+   - ./bootstrap-vcpkg.sh # bootstrap-vcpkg.bat for Powershell
    - ./vcpkg integrate install
    - ./vcpkg install cmark
 


### PR DESCRIPTION
`cppzmq` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `cppzmq` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `cppzmq`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/cppzmq/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊