### PR TITLE
Rebuild with string_view argument, like the constructor

### DIFF
--- a/tests/message.cpp
+++ b/tests/message.cpp
@@ -179,6 +179,37 @@ TEST_CASE("message equality non equal lhs empty", "[message]")
     CHECK(msg_a != msg_b);
 }
 
+TEST_CASE("message rebuild with size", "[message]")
+{
+    const zmq::message_t msg();
+    msg.rebuild(5)
+    CHECK(msg.size() == 5);
+}
+
+#if defined(ZMQ_CPP11) && !defined(ZMQ_CPP11_PARTIAL)
+TEST_CASE("message rebuild with strings", "[message]")
+{
+    SECTION("string")
+    {
+        const std::string hi(data);
+        zmq::message_t hi_msg();
+        hi_msg.rebuild(hi)
+        CHECK(2u == hi_msg.size());
+        CHECK(0 == memcmp(data, hi_msg.data(), 2));
+    }
+#if CPPZMQ_HAS_STRING_VIEW
+    SECTION("string_view")
+    {
+        const std::string_view hi(data);
+        zmq::message_t hi_msg();
+        hi_msg.rebuild(hi)
+        CHECK(2u == hi_msg.size());
+        CHECK(0 == memcmp(data, hi_msg.data(), 2));
+    }
+#endif
+}
+#endif
+
 TEST_CASE("message to string", "[message]")
 {
     const zmq::message_t a;

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -544,6 +544,13 @@ class message_t
         rebuild(str.data(), str.size());
     }
 
+#if CPPZMQ_HAS_STRING_VIEW
+    void rebuild(std::string_view str)
+    {
+        rebuild(str.data(), str.size());
+    }
+#endif
+
     void rebuild(void *data_, size_t size_, free_fn *ffn_, void *hint_ = ZMQ_NULLPTR)
     {
         int rc = zmq_msg_close(&msg);


### PR DESCRIPTION
More convenient, like the constructor `message_t(std::string_view str)`

This is similar to PR #579 but with `std::string_view` instead of `std::string&`.