### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 
 project(cppzmq-examples CXX)
 


### PR DESCRIPTION
Require at least cmake 3.11 to run examples, as its required in main CMakeLists.txt file. Newer cmake issue errors with version less then 3.5 See e.g. https://bugs.debian.org/1040723