### PR TITLE
Feature/expose monitor socket for active poller

### DIFF
--- a/tests/monitor.cpp
+++ b/tests/monitor.cpp
@@ -154,6 +154,8 @@ TEST_CASE("monitor from move assigned socket", "[monitor]")
 #if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)                              \
   && !defined(ZMQ_CPP11_PARTIAL) && defined(ZMQ_HAVE_POLLER)
 #include "zmq_addon.hpp"
+#include <chrono>
+
 using namespace std::literals::chrono_literals;
 
 TEST_CASE("poll monitor events using active poller", "[monitor]")

--- a/tests/monitor.cpp
+++ b/tests/monitor.cpp
@@ -172,7 +172,7 @@ TEST_CASE("poll monitor events using active poller", "[monitor]")
         void addToPoller(zmq::active_poller_t &inActivePoller)
         {
             inActivePoller.add(
-              _monitor_socket, zmq::event_flags::pollin,
+              monitor_socket(), zmq::event_flags::pollin,
               [&](zmq::event_flags ef) { process_event(static_cast<short>(ef)); });
         }
 

--- a/tests/monitor.cpp
+++ b/tests/monitor.cpp
@@ -8,7 +8,7 @@
 
 class mock_monitor_t : public zmq::monitor_t
 {
-public:
+  public:
 
     void on_event_connected(const zmq_event_t &, const char *) ZMQ_OVERRIDE
     {
@@ -89,7 +89,7 @@ TEST_CASE("monitor init abort", "[monitor]")
 {
     class mock_monitor : public mock_monitor_t
     {
-    public:
+      public:
         mock_monitor(std::function<void(void)> handle_connected) :
             handle_connected{std::move(handle_connected)}
         {
@@ -128,7 +128,7 @@ TEST_CASE("monitor init abort", "[monitor]")
     {
         std::unique_lock<std::mutex> lock(mutex);
         CHECK(cond_var.wait_for(lock, std::chrono::seconds(1),
-            [&done] { return done; }));
+                                [&done] { return done; }));
     }
     CHECK(monitor.connected == 1);
     monitor.abort();
@@ -148,5 +148,92 @@ TEST_CASE("monitor from move assigned socket", "[monitor]")
     monitor1.init(sock, "inproc://monitor-client");
     // On failure, this test might hang indefinitely instead of immediately
     // failing
+}
+#endif
+
+#if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)                              \
+  && !defined(ZMQ_CPP11_PARTIAL) && defined(ZMQ_HAVE_POLLER)
+#include "zmq_addon.hpp"
+using namespace std::literals::chrono_literals;
+
+TEST_CASE("poll monitor events using active poller", "[monitor]")
+{
+    // define necessary class for test
+    class test_monitor : public zmq::monitor_t
+    {
+      public:
+        void init(zmq::socket_t &socket,
+                  const char *const addr_,
+                  int events = ZMQ_EVENT_ALL)
+        {
+            zmq::monitor_t::init(socket, addr_, events);
+        }
+
+        void addToPoller(zmq::active_poller_t &inActivePoller)
+        {
+            inActivePoller.add(
+              _monitor_socket, zmq::event_flags::pollin,
+              [&](zmq::event_flags ef) { process_event(static_cast<short>(ef)); });
+        }
+
+        void on_event_accepted(const zmq_event_t &event_,
+                                       const char *addr_) override
+        {
+            clientAccepted++;
+        }
+        void on_event_disconnected(const zmq_event_t &event,
+                                   const char *const addr) override
+        {
+            clientDisconnected++;
+        }
+
+        int clientAccepted = 0;
+        int clientDisconnected = 0;
+    };
+
+    //Arrange
+    int messageCounter = 0;
+    const char monitorAddress[] = "inproc://monitor-server";
+
+    auto addToPoller = [&](zmq::socket_t &socket, zmq::active_poller_t &poller) {
+        poller.add(socket, zmq::event_flags::pollin, [&](zmq::event_flags ef) {
+            zmq::message_t msg;
+            auto result = socket.recv(msg, zmq::recv_flags::dontwait);
+            messageCounter++;
+        });
+    };
+
+    common_server_client_setup sockets(false);
+
+    test_monitor monitor;
+    monitor.init(sockets.server, monitorAddress);
+
+    zmq::active_poller_t poller;
+    monitor.addToPoller(poller);
+    addToPoller(sockets.server, poller);
+
+    sockets.init();
+    sockets.client.send(zmq::message_t(0), zmq::send_flags::dontwait);
+    CHECK(monitor.clientAccepted == 0);
+    CHECK(monitor.clientDisconnected == 0);
+
+    //Act
+    for (int i = 0; i < 10; i++) {
+        poller.wait(10ms);
+    }
+    CHECK(monitor.clientAccepted == 1);
+    CHECK(monitor.clientDisconnected == 0);
+
+    sockets.client.close();
+
+    for (int i = 0; i < 10; i++) {
+        poller.wait(10ms);
+    }
+    sockets.server.close();
+
+    // Assert
+    CHECK(messageCounter == 1);
+    CHECK(monitor.clientAccepted == 1);
+    CHECK(monitor.clientDisconnected == 1);
 }
 #endif

--- a/tests/monitor.cpp
+++ b/tests/monitor.cpp
@@ -154,9 +154,6 @@ TEST_CASE("monitor from move assigned socket", "[monitor]")
 #if defined(ZMQ_BUILD_DRAFT_API) && defined(ZMQ_CPP11)                              \
   && !defined(ZMQ_CPP11_PARTIAL) && defined(ZMQ_HAVE_POLLER)
 #include "zmq_addon.hpp"
-#include <chrono>
-
-using namespace std::literals::chrono_literals;
 
 TEST_CASE("poll monitor events using active poller", "[monitor]")
 {
@@ -221,7 +218,7 @@ TEST_CASE("poll monitor events using active poller", "[monitor]")
 
     //Act
     for (int i = 0; i < 10; i++) {
-        poller.wait(10ms);
+        poller.wait(std::chrono::milliseconds(10));
     }
     CHECK(monitor.clientAccepted == 1);
     CHECK(monitor.clientDisconnected == 0);
@@ -229,7 +226,7 @@ TEST_CASE("poll monitor events using active poller", "[monitor]")
     sockets.client.close();
 
     for (int i = 0; i < 10; i++) {
-        poller.wait(10ms);
+        poller.wait(std::chrono::milliseconds(10));
     }
     sockets.server.close();
 

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -2589,13 +2589,14 @@ class monitor_t
         return true;
     }
 
-    socket_t _monitor_socket;
+    socket_ref monitor_socket() {return _monitor_socket;}
 
   private:
     monitor_t(const monitor_t &) ZMQ_DELETED_FUNCTION;
     void operator=(const monitor_t &) ZMQ_DELETED_FUNCTION;
 
     socket_ref _socket;
+    socket_t _monitor_socket;
 
     void close() ZMQ_NOTHROW
     {

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -2362,8 +2362,6 @@ class monitor_t
     {
         assert(_monitor_socket);
 
-        zmq::message_t eventMsg;
-
         zmq::pollitem_t items[] = {
           {_monitor_socket.handle(), 0, ZMQ_POLLIN, 0},
         };
@@ -2374,7 +2372,14 @@ class monitor_t
         zmq::poll(&items[0], 1, timeout);
         #endif
 
-        if (items[0].revents & ZMQ_POLLIN) {
+        return process_event(items[0].revents);
+    }
+    
+    bool process_event(short events)
+    {
+        zmq::message_t eventMsg;
+
+        if (events & ZMQ_POLLIN) {
             int rc = zmq_msg_recv(eventMsg.handle(), _monitor_socket.handle(), 0);
             if (rc == -1 && zmq_errno() == ETERM)
                 return false;


### PR DESCRIPTION
Motivation:
`zmq::monitor_t` in it's current form is inconvenient to use in combination with `zmq::active_poller_t`
the issue is, that the socket isn't available to the user of `zmq::monitor_t`

Proposal:
split `zmq::monitor_t::check_event()` to move the actual reading and processing of the events into a new protected method `zmq::monitor_t::process_event()`
provide a protected socket_ref for using the monitor_socket for polling in a derived class.

Execution:
The proposed changes were done to`zmq.hpp`
A test case demonstrating the desired usage was added to `tests/monitor.cpp`


By inheriting from `zmq::monitor_t` you can now implement custom ways of polling for socket events.
The modified api is hidden for "rookie" users that might accidentaly call `process_event()` without polling for changes before use.