### PR TITLE
allow generic sequence of poller events

### DIFF
--- a/tests/poller.cpp
+++ b/tests/poller.cpp
@@ -192,6 +192,21 @@ TEST_CASE("poller poll basic", "[poller]")
     CHECK(&i == events[0].user_data);
 }
 
+TEST_CASE("poller poll basic static array", "[poller]")
+{
+    common_server_client_setup s;
+
+    CHECK_NOTHROW(s.client.send(zmq::message_t{hi_str}, zmq::send_flags::none));
+
+    zmq::poller_t<int> poller;
+    std::array<zmq::poller_event<int>, 1> events;
+    int i = 0;
+    CHECK_NOTHROW(poller.add(s.server, zmq::event_flags::pollin, &i));
+    CHECK(1 == poller.wait_all(events, std::chrono::milliseconds{-1}));
+    CHECK(s.server == events[0].socket);
+    CHECK(&i == events[0].user_data);
+}
+
 TEST_CASE("poller add invalid socket throws", "[poller]")
 {
     zmq::context_t context;

--- a/zmq.hpp
+++ b/zmq.hpp
@@ -108,6 +108,7 @@
 #include <cassert>
 #include <cstring>
 
+#include <type_traits>
 #include <algorithm>
 #include <exception>
 #include <iomanip>
@@ -2714,9 +2715,12 @@ template<typename T = no_user_data> class poller_t
         }
     }
 
-    size_t wait_all(std::vector<event_type> &poller_events,
+    template <typename Sequence>
+    size_t wait_all(Sequence &poller_events,
                     const std::chrono::milliseconds timeout)
     {
+        static_assert(std::is_same<typename Sequence::value_type, event_type>::value,
+                      "Sequence::value_type must be of poller_t::event_type");
         int rc = zmq_poller_wait_all(
           poller_ptr.get(),
           reinterpret_cast<zmq_poller_event_t *>(poller_events.data()),


### PR DESCRIPTION
To avoid allocating (due to std::vector), I would like to use a static array for creating poller events. However, the `wait_all` method currently is hardcoded to accept only vectors. This PR addresses that by making `wait_all` a templated function.