### PR TITLE
Add on_monitor_stopped function for monitor_t

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -2384,6 +2384,8 @@ class monitor_t
 
         _socket = socket_ref();
     }
+
+    virtual void on_monitor_stopped() {}
 #endif
     virtual void on_monitor_started() {}
     virtual void on_event_connected(const zmq_event_t &event_, const char *addr_)
@@ -2525,6 +2527,7 @@ class monitor_t
 
 #ifdef ZMQ_EVENT_MONITOR_STOPPED
         if (event->event == ZMQ_EVENT_MONITOR_STOPPED) {
+            on_monitor_stopped();
             return false;
         }
 


### PR DESCRIPTION
Currently `ZMQ_EVENT_MONITOR_STOPPED` directly returns from function without an indicator. With a `on_monitor_stopped` function callback anyone can distinguish stop event from errors and might log this event.