### PR TITLE
Fix deprecated literal operator

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1364,19 +1364,19 @@ constexpr const_buffer str_buffer(const Char (&data)[N]) noexcept
 
 namespace literals
 {
-constexpr const_buffer operator"" _zbuf(const char *str, size_t len) noexcept
+constexpr const_buffer operator ""_zbuf(const char *str, size_t len) noexcept
 {
     return const_buffer(str, len * sizeof(char));
 }
-constexpr const_buffer operator"" _zbuf(const wchar_t *str, size_t len) noexcept
+constexpr const_buffer operator ""_zbuf(const wchar_t *str, size_t len) noexcept
 {
     return const_buffer(str, len * sizeof(wchar_t));
 }
-constexpr const_buffer operator"" _zbuf(const char16_t *str, size_t len) noexcept
+constexpr const_buffer operator ""_zbuf(const char16_t *str, size_t len) noexcept
 {
     return const_buffer(str, len * sizeof(char16_t));
 }
-constexpr const_buffer operator"" _zbuf(const char32_t *str, size_t len) noexcept
+constexpr const_buffer operator ""_zbuf(const char32_t *str, size_t len) noexcept
 {
     return const_buffer(str, len * sizeof(char32_t));
 }


### PR DESCRIPTION
On clang 20, this happens:

```
$ clang++-20 zmq.hpp
zmq.hpp:1367:35: warning: identifier '_zbuf' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
 1367 | constexpr const_buffer operator"" _zbuf(const char *str, size_t len) noexcept
      |                        ~~~~~~~~~~~^~~~~
      |                        operator""_zbuf
zmq.hpp:1371:35: warning: identifier '_zbuf' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
 1371 | constexpr const_buffer operator"" _zbuf(const wchar_t *str, size_t len) noexcept
      |                        ~~~~~~~~~~~^~~~~
      |                        operator""_zbuf
zmq.hpp:1375:35: warning: identifier '_zbuf' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
 1375 | constexpr const_buffer operator"" _zbuf(const char16_t *str, size_t len) noexcept
      |                        ~~~~~~~~~~~^~~~~
      |                        operator""_zbuf
zmq.hpp:1379:35: warning: identifier '_zbuf' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
 1379 | constexpr const_buffer operator"" _zbuf(const char32_t *str, size_t len) noexcept
      |                        ~~~~~~~~~~~^~~~~
      |                        operator""_zbuf
4 warnings generated.
```