### PR TITLE
Remove space in custom string literal

### DIFF
--- a/zmq.hpp
+++ b/zmq.hpp
@@ -1364,19 +1364,19 @@ constexpr const_buffer str_buffer(const Char (&data)[N]) noexcept
 
 namespace literals
 {
-constexpr const_buffer operator"" _zbuf(const char *str, size_t len) noexcept
+constexpr const_buffer operator""_zbuf(const char *str, size_t len) noexcept
 {
     return const_buffer(str, len * sizeof(char));
 }
-constexpr const_buffer operator"" _zbuf(const wchar_t *str, size_t len) noexcept
+constexpr const_buffer operator""_zbuf(const wchar_t *str, size_t len) noexcept
 {
     return const_buffer(str, len * sizeof(wchar_t));
 }
-constexpr const_buffer operator"" _zbuf(const char16_t *str, size_t len) noexcept
+constexpr const_buffer operator""_zbuf(const char16_t *str, size_t len) noexcept
 {
     return const_buffer(str, len * sizeof(char16_t));
 }
-constexpr const_buffer operator"" _zbuf(const char32_t *str, size_t len) noexcept
+constexpr const_buffer operator""_zbuf(const char32_t *str, size_t len) noexcept
 {
     return const_buffer(str, len * sizeof(char32_t));
 }


### PR DESCRIPTION
I may lack sufficient context for this to be a useful PR, so please feel free to close if this is not welcome.

For no particular reason I saw an analogous PR to another R package repo in my GitHub home page:

https://github.com/marzer/tomlplusplus/pull/263

I searched the main R package repo for other similarly-affected packages, which includes {clustermq}, which bundles this repo as a submodule:

https://github.com/mschubert/clustermq/tree/master/src

Here's the documentation I could find about why this matters:

https://en.cppreference.com/w/cpp/language/user_literal

```c++
// error: all names that begin with underscore followed by uppercase
// letter are reserved (NOTE: a space between "" and _).
double operator"" _Z(long double);
```