### PR TITLE
Add Debian packaging 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,9 @@ include(InstallRequiredSystemLibraries)
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 set(CPACK_GENERATOR "DEB")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Daniel Fundarek")
-set(CPACK_PACKAGE_DESCRIPTION "cppzmq is a C++ binding for libzmq.")
+set(CPACK_PACKAGE_DESCRIPTION 
+  "cppzmq project provides a C++ binding for the libzmq library. 
+  Installation of cppzmq debian package also installs libzmq3-dev as dependency.")
 set(CPACK_PACKAGE_CONTACT "daniel.fundarek@airvolute.com")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
               DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR}/libzmq-pkg-config)
 
-option(CPPZMQ_BUILD_TESTS "Whether or not to build the tests" ON)
+option(CPPZMQ_BUILD_TESTS "Whether or not to build the tests" OFF)
 
 if (CPPZMQ_BUILD_TESTS)
     enable_testing()
@@ -99,3 +99,26 @@ if (CPPZMQ_BUILD_TESTS)
         add_subdirectory(examples)
     endif()
 endif()
+
+
+#############
+# Packaging #
+#############
+
+include(InstallRequiredSystemLibraries)
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+set(CPACK_GENERATOR "DEB")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Daniel Fundarek")
+set(CPACK_PACKAGE_DESCRIPTION "cppzmq is a C++ binding for libzmq.")
+set(CPACK_PACKAGE_CONTACT "daniel.fundarek@airvolute.com")
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_DEPENDS
+  "libzmq3-dev (>= ${ZeroMQ_VERSION})"
+)
+
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
+)
+set(CPACK_SET_DESTDIR OFF)
+set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
+
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/libzmq-pkg-config/FindZeroMQ.cmake
               DESTINATION ${CPPZMQ_CMAKECONFIG_INSTALL_DIR}/libzmq-pkg-config)
 
-option(CPPZMQ_BUILD_TESTS "Whether or not to build the tests" OFF)
+option(CPPZMQ_BUILD_TESTS "Whether or not to build the tests" ON)
 
 if (CPPZMQ_BUILD_TESTS)
     enable_testing()
@@ -115,7 +115,7 @@ set(CPACK_PACKAGE_DESCRIPTION
 set(CPACK_PACKAGE_CONTACT "daniel.fundarek@airvolute.com")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-  "libzmq3-dev (>= ${ZeroMQ_VERSION})"
+  "libzmq3-dev"
 )
 
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA

--- a/README.md
+++ b/README.md
@@ -163,14 +163,15 @@ Build instructions
 Build steps:
 1.Install libzmq from apt repository
    - `sudo apt install libzmq3-dev`
-2. Build cppzmq via cmake. pack with cpack and install debian package via apt.
+2. Build cppzmq via cmake, pack with cpack, and install the Debian package via apt.
    - `git clone https://github.com/zeromq/cppzmq.git`
    - `cd cppzmq`
    - `mkdir build`
    - `cd build`
-   - `make -j(n_proc)`
+   - `cmake ..`
+   - `make -j$(nproc)`
    - `cpack`
-   - `sudo apt install ./cppzmq*`
+   - `sudo apt install ./cppzmq*.deb`
 
 
 or use legacy build:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Build steps:
    - `cd build`
    - `make -j(n_proc)`
    - `cpack`
-   - `sudo apt install cppzmq`
+   - `sudo apt install ./cppzmq*`
 
 
 or use legacy build:

--- a/README.md
+++ b/README.md
@@ -161,6 +161,19 @@ Build instructions
 ==================
 
 Build steps:
+1.Install libzmq from apt repository
+   - `sudo apt install libzmq3-dev`
+2. Build cppzmq via cmake. pack with cpack and install debian package via apt.
+   - `git clone https://github.com/zeromq/cppzmq.git`
+   - `cd cppzmq`
+   - `mkdir build`
+   - `cd build`
+   - `make -j(n_proc)`
+   - `cpack`
+   - `sudo apt install cppzmq`
+
+
+or use legacy build:
 
 1. Build [libzmq](https://github.com/zeromq/libzmq) via cmake. This does an out of source build and installs the build files
    - `git clone https://github.com/zeromq/libzmq.git`


### PR DESCRIPTION
This pull request adds Debian package generation via CPack. The generated package declares libzmq3-dev as a dependency, so developers only need to install the cppzmq package to obtain full cppzmq development support.