### PR TITLE
feat: add send_flags overload for multipart_t::send

### DIFF
--- a/tests/multipart.cpp
+++ b/tests/multipart.cpp
@@ -6,11 +6,19 @@
 #ifdef ZMQ_HAS_RVALUE_REFS
 
 #ifdef ZMQ_CPP17
-static_assert(std::is_invocable<decltype(&zmq::multipart_t::send),
+using multipart_send_int_t = bool (zmq::multipart_t::*)(zmq::socket_ref, int);
+using multipart_send_flags_t = bool (zmq::multipart_t::*)(zmq::socket_ref,
+                                                          zmq::send_flags);
+static_assert(std::is_invocable<multipart_send_int_t,
                                 zmq::multipart_t *,
                                 zmq::socket_ref,
                                 int>::value,
               "Can't multipart_t::send with socket_ref");
+static_assert(std::is_invocable<multipart_send_flags_t,
+                                zmq::multipart_t *,
+                                zmq::socket_ref,
+                                zmq::send_flags>::value,
+              "Can't multipart_t::send with send_flags");
 static_assert(std::is_invocable<decltype(&zmq::multipart_t::recv),
                                 zmq::multipart_t *,
                                 zmq::socket_ref,
@@ -60,7 +68,7 @@ TEST_CASE("multipart legacy test", "[multipart]")
     multipart.push(message_t("Hello", 5));
     assert(multipart.size() == 1);
 
-    ok = multipart.send(output);
+    ok = multipart.send(output, send_flags::none);
     assert(multipart.empty());
     assert(ok);
 

--- a/zmq_addon.hpp
+++ b/zmq_addon.hpp
@@ -491,6 +491,13 @@ class multipart_t
         return true;
     }
 
+#ifdef ZMQ_CPP11
+    bool send(socket_ref socket, send_flags flags)
+    {
+        return send(socket, static_cast<int>(flags));
+    }
+#endif
+
     // Concatenate other multipart to front
     void prepend(multipart_t &&other)
     {


### PR DESCRIPTION
# Update zmq::multipart_t::send to support zmq::send_flags

Fixes zeromq/cppzmq#664.

## Summary

- Add a `send_flags` overload for `zmq::multipart_t::send`.
- Keep the existing integer-based overload for backward compatibility.
- Forward the new overload to the existing implementation so current behavior stays unchanged.

## Notes

This is a small API improvement in the header-only `zmq_addon.hpp` file. It makes multipart send calls consistent with the rest of the modern cppzmq API.
